### PR TITLE
Add shortcuts for slicing rows and columns

### DIFF
--- a/include/matrix.h
+++ b/include/matrix.h
@@ -179,6 +179,14 @@ class Matrix : public MatrixExpression<Matrix<TDataType, TSize1, TSize2>,
     TransposeMatrix<Matrix<TDataType, TSize1, TSize2>> transpose() {
         return TransposeMatrix<Matrix<TDataType, TSize1, TSize2>>(*this);
     }
+
+    MatrixRow<Matrix<TDataType, TSize1, TSize2>> row(std::size_t i) {
+        return MatrixRow<Matrix<TDataType, TSize1, TSize2>>(*this, i);
+    }
+
+    MatrixColumn<Matrix<TDataType, TSize1, TSize2>> col(std::size_t i) {
+        return MatrixColumn<Matrix<TDataType, TSize1, TSize2>>(*this, i);
+    }
 };
 
 template <typename TDataType, std::size_t TSize1, std::size_t TSize2>
@@ -195,6 +203,22 @@ inline std::ostream& operator<<(std::ostream& rOStream,
     for (std::size_t i = 0; i < TheMatrix.size1(); i++) {
         for (std::size_t j = 0; j < TheMatrix.size2(); j++)
             rOStream << TheMatrix(i, j) << ',';
+        rOStream << '\n';
+    }
+    rOStream << '}';
+
+    return rOStream;
+}
+
+template <typename TExpressionType, std::size_t TCategory>
+inline std::ostream& operator<<(std::ostream& rOStream,
+    MatrixExpression<TExpressionType, TCategory> const& TheMatrixExpression) {
+    auto& expression = TheMatrixExpression.expression();
+
+    rOStream << '{';
+    for (std::size_t i = 0; i < expression.size1(); i++) {
+        for (std::size_t j = 0; j < expression.size2(); j++)
+            rOStream << expression(i, j) << ',';
         rOStream << '\n';
     }
     rOStream << '}';

--- a/test/test_matrix_column.cpp
+++ b/test/test_matrix_column.cpp
@@ -10,8 +10,8 @@ std::size_t TestMatrixColumnAcess() {
     }
 
     for (std::size_t j = 0; j < a_matrix.size2(); j++) {
-        const AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_column_j(
-            a_matrix, j);
+        const AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_column_j =
+            a_matrix.col(j);
 
         for (std::size_t i = 0; i < a_matrix.size1(); i++) {
             AMATRIX_CHECK_EQUAL(a_column_j(i, 0), a_matrix(i, j));
@@ -26,8 +26,8 @@ template <std::size_t TSize1, std::size_t TSize2>
 std::size_t TestMatrixColumnAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t j = 0; j < a_matrix.size2(); j++) {
-        AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_column_j(
-            a_matrix, j);
+        AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_column_j =
+            a_matrix.col(j);
         AMATRIX_CHECK_EQUAL(a_column_j.size(), TSize1);
         AMATRIX_CHECK_EQUAL(a_column_j.size1(), TSize1);
         AMATRIX_CHECK_EQUAL(a_column_j.size2(), 1);
@@ -43,7 +43,7 @@ std::size_t TestMatrixColumnAssign() {
 
     for (std::size_t j = 0; j < a_matrix.size2(); j++) {
         AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>>
-            a_column_j(a_matrix, j);
+            a_column_j = a_matrix.col(j);
         AMATRIX_CHECK_EQUAL(a_column_j.size(), TSize1);
         AMATRIX_CHECK_EQUAL(a_column_j.size1(), TSize1);
         AMATRIX_CHECK_EQUAL(a_column_j.size2(), 1);
@@ -64,8 +64,8 @@ template <std::size_t TSize1, std::size_t TSize2>
 std::size_t TestMatrixColumnExpressionAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t j = 0; j < a_matrix.size2(); j++) {
-        AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_column_j(
-            a_matrix, j);
+        AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_column_j =
+            a_matrix.col(j);
         AMatrix::Matrix<double, 1, TSize1> b_vector;
         for (std::size_t i = 0; i < a_matrix.size1(); i++)
             b_vector[i] = 2.33 * i - 4.52 * j;

--- a/test/test_matrix_row.cpp
+++ b/test/test_matrix_row.cpp
@@ -10,8 +10,8 @@ std::size_t TestMatrixRowAcess() {
     }
 
     for (std::size_t i = 0; i < a_matrix.size1(); i++) {
-        const AMatrix::MatrixRow<AMatrix::Matrix<double, TSize1, TSize2>> a_row_i(
-            a_matrix, i);
+        const AMatrix::MatrixRow<AMatrix::Matrix<double, TSize1, TSize2>>a_row_i =
+            a_matrix.row(i);
         for (std::size_t j = 0; j < a_matrix.size2(); j++) {
             AMATRIX_CHECK_EQUAL(a_row_i(0, j), a_matrix(i, j));
             AMATRIX_CHECK_EQUAL(a_row_i[j], a_matrix(i, j));
@@ -25,8 +25,8 @@ template <std::size_t TSize1, std::size_t TSize2>
 std::size_t TestMatrixRowAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++) {
-        AMatrix::MatrixRow<AMatrix::Matrix<double, TSize1, TSize2>> a_row_i(
-            a_matrix, i);
+        AMatrix::MatrixRow<AMatrix::Matrix<double, TSize1, TSize2>> a_row_i =
+            a_matrix.row(i);
         AMATRIX_CHECK_EQUAL(a_row_i.size(), TSize2);
         AMATRIX_CHECK_EQUAL(a_row_i.size1(), 1);
         AMATRIX_CHECK_EQUAL(a_row_i.size2(), TSize2);
@@ -41,8 +41,8 @@ std::size_t TestMatrixRowAssign() {
     }
 
     for (std::size_t i = 0; i < a_matrix.size1(); i++) {
-        AMatrix::MatrixRow<AMatrix::Matrix<double, TSize1, TSize2>> a_row_i(
-            a_matrix, i);
+        AMatrix::MatrixRow<AMatrix::Matrix<double, TSize1, TSize2>> a_row_i =
+            a_matrix.row(i);
         AMATRIX_CHECK_EQUAL(a_row_i.size(), TSize2);
         AMATRIX_CHECK_EQUAL(a_row_i.size1(), 1);
         AMATRIX_CHECK_EQUAL(a_row_i.size2(), TSize2);
@@ -63,8 +63,8 @@ template <std::size_t TSize1, std::size_t TSize2>
 std::size_t TestMatrixRowExpressionAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++) {
-        AMatrix::MatrixRow<AMatrix::Matrix<double, TSize1, TSize2>> a_row_i(
-            a_matrix, i);
+        AMatrix::MatrixRow<AMatrix::Matrix<double, TSize1, TSize2>> a_row_i =
+            a_matrix.row(i);
         AMatrix::Matrix<double, 1, TSize2> b_vector;
         for (std::size_t j = 0; j < a_matrix.size2(); j++)
             b_vector[j] = 2.33 * i - 4.52 * j;


### PR DESCRIPTION
A very simple implementation for accessing rows and columns by index.

**Still not possible:**
`matrix.row(0).col(0)`
Possible without adding virtual functions to `MatrixExpression`?