### PR TITLE
Add aliasing check

### DIFF
--- a/include/matrix.h
+++ b/include/matrix.h
@@ -177,9 +177,10 @@ class Matrix : public MatrixExpression<Matrix<TDataType, TSize1, TSize2>,
 
     bool check_aliasing(const data_type* From, const data_type* To) const {
         const data_type* const end_pointer = data() + size();
-        return ((From <= data()) && (data() < To)) ||
-               ((From <= end_pointer) && (end_pointer < To)) ||
-               ((From > data() && (To <= end_pointer)));
+        bool check1 = ((From <= data()) && (data() < To));
+        bool check2 = ((From < end_pointer) && (end_pointer < To));
+        bool check3 = ((From > data()) && (To <= end_pointer));
+        return ( check1 || check2 || check3 );
     }
 
         TransposeMatrix<Matrix<TDataType, TSize1, TSize2>> transpose() {

--- a/include/matrix.h
+++ b/include/matrix.h
@@ -192,7 +192,7 @@ class Matrix : public MatrixExpression<Matrix<TDataType, TSize1, TSize2>,
         return MatrixRow<Matrix<TDataType, TSize1, TSize2>>(*this, i);
     }
 
-    MatrixColumn<Matrix<TDataType, TSize1, TSize2>> col(std::size_t i) {
+    MatrixColumn<Matrix<TDataType, TSize1, TSize2>> column(std::size_t i) {
         return MatrixColumn<Matrix<TDataType, TSize1, TSize2>>(*this, i);
     }
 };

--- a/include/matrix.h
+++ b/include/matrix.h
@@ -178,9 +178,10 @@ class Matrix : public MatrixExpression<Matrix<TDataType, TSize1, TSize2>,
     bool check_aliasing(const data_type* From, const data_type* To) const {
         const data_type* const end_pointer = data() + size();
         bool check1 = ((From <= data()) && (data() < To));
-        bool check2 = ((From < end_pointer) && (end_pointer < To));
+        bool check2 = ((From < end_pointer) && (end_pointer < To));  // I'm not sure if should be =< To. Pooyan.
         bool check3 = ((From > data()) && (To <= end_pointer));
-        return ( check1 || check2 || check3 );
+
+        return (check1 || check2 || check3);
     }
 
         TransposeMatrix<Matrix<TDataType, TSize1, TSize2>> transpose() {

--- a/include/matrix.h
+++ b/include/matrix.h
@@ -22,10 +22,9 @@ class Matrix : public MatrixExpression<Matrix<TDataType, TSize1, TSize2>,
     using base_type::size;
     using base_type::size1;
     using base_type::size2;
-    
+
     using iterator = RandomAccessIterator<TDataType>;
     using const_iterator = RandomAccessIterator<const TDataType>;
-
 
     Matrix() {}
 
@@ -45,7 +44,7 @@ class Matrix : public MatrixExpression<Matrix<TDataType, TSize1, TSize2>,
 
     explicit Matrix(std::initializer_list<TDataType> InitialValues)
         : base_type(InitialValues) {}
-	 
+
     template <typename TExpressionType, std::size_t TCategory>
     Matrix& operator=(
         MatrixExpression<TExpressionType, TCategory> const& Other) {
@@ -139,9 +138,7 @@ class Matrix : public MatrixExpression<Matrix<TDataType, TSize1, TSize2>,
 
     void resize(std::size_t NewSize) { base_type::resize(NewSize); }
 
-    void swap(Matrix& Other){
-        base_type::swap(Other);
-    }
+    void swap(Matrix& Other) { base_type::swap(Other); }
 
     iterator begin() { return iterator(data()); }
 
@@ -178,7 +175,12 @@ class Matrix : public MatrixExpression<Matrix<TDataType, TSize1, TSize2>,
 
     Matrix& noalias() { return *this; }
 
-    TransposeMatrix<Matrix<TDataType, TSize1, TSize2>> transpose() {
+	bool check_aliasing(data_type* From, data_type* To){
+        return ((From >= begin()) && (begin() > To)) ||
+               ((From >= end()) && (end() > To));
+	}
+
+        TransposeMatrix<Matrix<TDataType, TSize1, TSize2>> transpose() {
         return TransposeMatrix<Matrix<TDataType, TSize1, TSize2>>(*this);
     }
 
@@ -213,8 +215,8 @@ inline std::ostream& operator<<(std::ostream& rOStream,
         return rOStream;
     }
 
-    std::size_t column_width { 0 };
-    
+    std::size_t column_width{0};
+
     for (std::size_t j = 0; j < TheMatrix.size2(); j++) {
         for (std::size_t i = 0; i < TheMatrix.size1(); i++) {
             std::stringstream coeffStream;
@@ -225,19 +227,19 @@ inline std::ostream& operator<<(std::ostream& rOStream,
     }
 
     rOStream << matrix_prefix;
-    
+
     for (std::size_t i = 0; i < TheMatrix.size1(); i++) {
         rOStream << row_prefix;
 
         if (column_width != 0) {
             rOStream.width(column_width);
         }
-        
+
         rOStream << TheMatrix(i, 0);
-        
+
         for (std::size_t j = 1; j < TheMatrix.size2(); j++) {
             rOStream << col_separator;
-            
+
             if (column_width != 0) {
                 rOStream.width(column_width);
             }
@@ -251,7 +253,7 @@ inline std::ostream& operator<<(std::ostream& rOStream,
             rOStream << row_separator;
         }
     }
-    
+
     rOStream << matrix_suffix;
 
     return rOStream;

--- a/include/matrix.h
+++ b/include/matrix.h
@@ -175,10 +175,12 @@ class Matrix : public MatrixExpression<Matrix<TDataType, TSize1, TSize2>,
 
     Matrix& noalias() { return *this; }
 
-	bool check_aliasing(data_type* From, data_type* To){
-        return ((From >= begin()) && (begin() > To)) ||
-               ((From >= end()) && (end() > To));
-	}
+    bool check_aliasing(const data_type* From, const data_type* To) const {
+        const data_type* const end_pointer = data() + size();
+        return ((From <= data()) && (data() < To)) ||
+               ((From <= end_pointer) && (end_pointer < To)) ||
+               ((From > data() && (To <= end_pointer)));
+    }
 
         TransposeMatrix<Matrix<TDataType, TSize1, TSize2>> transpose() {
         return TransposeMatrix<Matrix<TDataType, TSize1, TSize2>>(*this);

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -402,6 +402,11 @@ class MatrixSumExpression
     inline data_type operator[](std::size_t i) const {
         return _first[i] + _second[i];
     }
+
+    bool check_aliasing(const data_type* From, const data_type* To) const {
+        return _first.check_aliasing(From, To) ||
+               _second.check_aliasing(From, To);
+    }
 };
 
 template <typename TExpression1Type, typename TExpression2Type,

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -486,6 +486,10 @@ class MatrixUnaryMinusExpression
     inline data_type operator[](std::size_t i) const {
         return -_original_expression[i];
     }
+
+    bool check_aliasing(const data_type* From, const data_type* To) const {
+        return _original_expression.check_aliasing(From, To);
+    }
 };
 
 template <typename TExpressionType>

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -446,6 +446,11 @@ class MatrixMinusExpression
     inline data_type operator[](std::size_t i) const {
         return _first[i] - _second[i];
     }
+
+    bool check_aliasing(const data_type* From, const data_type* To) const {
+        return _first.check_aliasing(From, To) ||
+               _second.check_aliasing(From, To);
+    }
 };
 
 template <typename TExpression1Type, typename TExpression2Type,

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -368,6 +368,10 @@ class IdentityMatrix
     inline std::size_t size1() const { return _size; }
     inline std::size_t size2() const { return _size; }
     inline std::size_t size() const { return _size * _size; }
+
+    bool check_aliasing(const data_type* From, const data_type* To) const {
+        return false;
+    }
 };
 
 template <typename TExpression1Type, typename TExpression2Type>

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -343,6 +343,10 @@ class ZeroMatrix
     inline std::size_t size2() const { return _size2; }
 
     inline std::size_t size() const { return _size1 * _size2; }
+
+    bool check_aliasing(const data_type* From, const data_type* To) const {
+        return false;
+    }
 };
 
 template <typename TDataType>

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -646,7 +646,7 @@ class LUFactorization
     /// The algorithm is based on wikipedia implemenation which
     /// can be found in https://en.wikipedia.org/wiki/LU_decomposition
     TMatrixType inverse() {
-        const std::size_t size = size1();
+        const int size = static_cast<int>(size1());
         TMatrixType result(size, size);
 
         for (std::size_t j = 0; j < size; j++) {
@@ -662,7 +662,7 @@ class LUFactorization
             }
 
             for (int i = size - 1; i >= 0; i--) {
-                for (std::size_t k = i + 1; k < size; k++)
+                for (int k = i + 1; k < size; k++)
                     result(i, j) -=
                         _matrix(_permutation_vector[i], k) * result(k, j);
 
@@ -687,8 +687,8 @@ class LUFactorization
                 result[i] -= _matrix(_permutation_vector[i], k) * result[k];
         }
 
-         for (int i = size - 1; i >= 0; i--) {
-            for (std::size_t k = i + 1; k < size; k++)
+         for (int i = static_cast<int>(size - 1); i >= 0; i--) {
+            for (int k = i + 1; k < static_cast<int>(size); k++)
                  result[i] -= _matrix(_permutation_vector[i], k) * result[k];
 
             result[i] /= _matrix(_permutation_vector[i], i);

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -640,6 +640,11 @@ class VectorOuterProductExpression
     inline data_type operator()(std::size_t i, std::size_t j) const {
         return _first[i] * _second[j];
     }
+
+    bool check_aliasing(const data_type* From, const data_type* To) const {
+        return _first.check_aliasing(From, To) ||
+               _second.check_aliasing(From, To);
+    }
 };
 
 template <typename TExpression1Type, typename TExpression2Type,

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -566,6 +566,10 @@ class MatrixScalarDivisionExpression
     inline data_type operator[](std::size_t i) const {
         return _first[i] * _inverse_of_second;
     }
+
+    bool check_aliasing(const data_type* From, const data_type* To) const {
+        return _first.check_aliasing(From, To);
+    }
 };
 
 template <typename TExpressionType, std::size_t TCategory>

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -121,6 +121,10 @@ class MatrixRow : public MatrixExpression<MatrixRow<TExpressionType>> {
     inline std::size_t size() const { return _original_expression.size2(); }
     inline std::size_t size1() const { return 1; }
     inline std::size_t size2() const { return _original_expression.size2(); }
+
+    bool check_aliasing(const data_type* From, const data_type* To) const {
+        return _original_expression.check_aliasing(From, To);
+    }
 };
 
 template <typename TExpressionType>

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -311,6 +311,10 @@ class SubVector
     data_type* data() { return &_original_expression[_origin_index]; }
 
     data_type const* data() const { return &_original_expression[_origin_index]; }
+
+    bool check_aliasing(const data_type* From, const data_type* To) const {
+        return _original_expression.check_aliasing(From, To);
+    }
 };
 
 template <typename TDataType>

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -238,6 +238,10 @@ class SubMatrix : public MatrixExpression<SubMatrix<TExpressionType>> {
     inline std::size_t size() const { return _size1 * _size2; }
     inline std::size_t size1() const { return _size1; }
     inline std::size_t size2() const { return _size2; }
+
+    bool check_aliasing(const data_type* From, const data_type* To) const {
+        return _original_expression.check_aliasing(From, To);
+    }
 };
 
 template <typename TExpressionType>

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -518,6 +518,10 @@ class MatrixScalarProductExpression
     inline data_type operator[](std::size_t i) const {
         return _first * _second[i];
     }
+
+    bool check_aliasing(const data_type* From, const data_type* To) const {
+        return _second.check_aliasing(From, To);
+    }
 };
 
 template <typename TExpressionType, std::size_t TCategory>

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -178,6 +178,10 @@ class MatrixColumn : public MatrixExpression<MatrixColumn<TExpressionType>> {
     inline std::size_t size() const { return _original_expression.size1(); }
     inline std::size_t size1() const { return _original_expression.size1(); }
     inline std::size_t size2() const { return 1; }
+
+    bool check_aliasing(const data_type* From, const data_type* To) const {
+        return _original_expression.check_aliasing(From, To);
+    }
 };
 
 template <typename TExpressionType>

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -64,6 +64,10 @@ class TransposeMatrix
 
     inline std::size_t size1() const { return _original_expression.size2(); }
     inline std::size_t size2() const { return _original_expression.size1(); }
+
+	bool check_aliasing(const data_type* From, const data_type* To) const {
+        return _original_expression.check_aliasing(From, To);
+	}
 };
 
 template <typename TExpressionType>

--- a/test/checks.h
+++ b/test/checks.h
@@ -1,17 +1,19 @@
 #define AMATRIX_CHECK(a)                               \
     if (!(a)) {                                          \
-        std::cout << #a << " is not true" << std::endl; \
+        std::cout << "in line " << __LINE__ << " : " << #a << " is not true" << std::endl; \
         return 1;                                      \
     }
 
 #define AMATRIX_CHECK_EQUAL(a, b)                                \
     if (a != b) {                                                \
-        std::cout << a << " is not equal to " << b << std::endl; \
+        std::cout << "in line " << __LINE__ << " : " << a   \
+                  << " is not equal to " << b << std::endl; \
         return 1;                                                \
     }
 
 #define AMATRIX_CHECK_ALMOST_EQUAL(a, b)                         \
     if (std::abs(a - b) > std::numeric_limits<double>::epsilon()) { \
-        std::cout << a << " is not equal to " << b << std::endl; \
+        std::cout << "in line " << __LINE__ << " : " << a           \
+                  << " is not equal to " << b << std::endl; \
         return 1;                                                \
     }

--- a/test/test_dynamic_matrix_access.cpp
+++ b/test/test_dynamic_matrix_access.cpp
@@ -1,7 +1,7 @@
 #include "amatrix.h"
 #include "checks.h"
 
-std::size_t TestDynamicMatrixAcess(std::size_t Size1, std::size_t Size2) {
+int TestDynamicMatrixAcess(std::size_t Size1, std::size_t Size2) {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(Size1, Size2);
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
         for (std::size_t j = 0; j < a_matrix.size2(); j++)
@@ -15,7 +15,7 @@ std::size_t TestDynamicMatrixAcess(std::size_t Size1, std::size_t Size2) {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestDynamicMatrixAcess(1, 1);
 
     number_of_failed_tests += TestDynamicMatrixAcess(1, 2);

--- a/test/test_dynamic_matrix_assign.cpp
+++ b/test/test_dynamic_matrix_assign.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestZeroMatrixAssign() {
+int TestZeroMatrixAssign() {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(1,1);
     a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
 
@@ -15,7 +15,7 @@ std::size_t TestZeroMatrixAssign() {
     return 0;  // not failed
 }
 
-std::size_t TestMatrixAssign(std::size_t Size1, std::size_t Size2) {
+int TestMatrixAssign(std::size_t Size1, std::size_t Size2) {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(Size1, Size2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> b_matrix(Size1, Size2);
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
@@ -34,7 +34,7 @@ std::size_t TestMatrixAssign(std::size_t Size1, std::size_t Size2) {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestZeroMatrixAssign<1, 1>();
 
     number_of_failed_tests += TestZeroMatrixAssign<1, 2>();

--- a/test/test_dynamic_matrix_initialize.cpp
+++ b/test/test_dynamic_matrix_initialize.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixInitializeToZero() {
+int TestMatrixInitializeToZero() {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(
         AMatrix::ZeroMatrix<double>(TSize1, TSize2));
 
@@ -13,7 +13,7 @@ std::size_t TestMatrixInitializeToZero() {
     return 0;  // not failed
 }
 
-std::size_t TestMatrixInitialize1() {
+int TestMatrixInitialize1() {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix{1.2};
 
     AMATRIX_CHECK_EQUAL(a_matrix.size1(), 1);
@@ -23,7 +23,7 @@ std::size_t TestMatrixInitialize1() {
     return 0;  // not failed
 }
 
-std::size_t TestMatrixInitialize2() {
+int TestMatrixInitialize2() {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix{1.2, 2.3};
 
     AMATRIX_CHECK_EQUAL(a_matrix.size1(), 1);
@@ -34,7 +34,7 @@ std::size_t TestMatrixInitialize2() {
     return 0;  // not failed
 }
 
-std::size_t TestMatrixInitialize3() {
+int TestMatrixInitialize3() {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix{ 1.2, 2.3, 3.4 };
 
     AMATRIX_CHECK_EQUAL(a_matrix.size1(), 1);
@@ -47,7 +47,7 @@ std::size_t TestMatrixInitialize3() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixInitializeToZero<1, 1>();
 
     number_of_failed_tests += TestMatrixInitializeToZero<1, 2>();

--- a/test/test_dynamic_matrix_minus.cpp
+++ b/test/test_dynamic_matrix_minus.cpp
@@ -1,7 +1,7 @@
 #include "amatrix.h"
 #include "checks.h"
 
-std::size_t TestMatrixMinus(std::size_t Size1, std::size_t Size2) {
+int TestMatrixMinus(std::size_t Size1, std::size_t Size2) {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(Size1, Size2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> b_matrix(Size1, Size2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> c_matrix(Size1, Size2);
@@ -19,7 +19,7 @@ std::size_t TestMatrixMinus(std::size_t Size1, std::size_t Size2) {
     return 0;  // not failed
 }
 
-std::size_t TestMatrixMinusEqual(std::size_t Size1, std::size_t Size2) {
+int TestMatrixMinusEqual(std::size_t Size1, std::size_t Size2) {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(Size1, Size2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> b_matrix(Size1, Size2);
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
@@ -36,7 +36,7 @@ std::size_t TestMatrixMinusEqual(std::size_t Size1, std::size_t Size2) {
     return 0;  // not failed
 }
 
-std::size_t TestMatrixUnaryMinus(std::size_t Size1, std::size_t Size2) {
+int TestMatrixUnaryMinus(std::size_t Size1, std::size_t Size2) {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(Size1, Size2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> b_matrix(Size1, Size2);
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
@@ -53,7 +53,7 @@ std::size_t TestMatrixUnaryMinus(std::size_t Size1, std::size_t Size2) {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
  	number_of_failed_tests += TestMatrixMinus(1,1);
 
 	number_of_failed_tests += TestMatrixMinus(1,2);

--- a/test/test_dynamic_matrix_plus.cpp
+++ b/test/test_dynamic_matrix_plus.cpp
@@ -1,7 +1,7 @@
 #include "amatrix.h"
 #include "checks.h"
 
-std::size_t TestMatrixPlus(std::size_t Size1, std::size_t Size2) {
+int TestMatrixPlus(std::size_t Size1, std::size_t Size2) {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(Size1, Size2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> b_matrix(Size1, Size2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> c_matrix(Size1, Size2);
@@ -19,7 +19,7 @@ std::size_t TestMatrixPlus(std::size_t Size1, std::size_t Size2) {
     return 0;  // not failed
 }
 
-std::size_t TestMatrixPlusEqual(std::size_t Size1, std::size_t Size2) {
+int TestMatrixPlusEqual(std::size_t Size1, std::size_t Size2) {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(Size1, Size2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> b_matrix(Size1, Size2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> c_matrix(Size1, Size2);
@@ -38,7 +38,7 @@ std::size_t TestMatrixPlusEqual(std::size_t Size1, std::size_t Size2) {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
 	number_of_failed_tests += TestMatrixPlus(1,1);
 
 	number_of_failed_tests += TestMatrixPlus(1,2);

--- a/test/test_dynamic_matrix_product.cpp
+++ b/test/test_dynamic_matrix_product.cpp
@@ -1,7 +1,7 @@
 #include "amatrix.h"
 #include "checks.h"
 
-std::size_t TestMatrixScalarProduct(std::size_t TSize1, std::size_t TSize2) {
+int TestMatrixScalarProduct(std::size_t TSize1, std::size_t TSize2) {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(TSize1, TSize2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> b_matrix(TSize1, TSize2);
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
@@ -20,7 +20,7 @@ std::size_t TestMatrixScalarProduct(std::size_t TSize1, std::size_t TSize2) {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixScalarSelfProduct() {
+int TestMatrixScalarSelfProduct() {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(TSize1, TSize2);
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
         for (std::size_t j = 0; j < a_matrix.size2(); j++)
@@ -35,7 +35,7 @@ std::size_t TestMatrixScalarSelfProduct() {
     return 0;  // not failed
 }
 
-std::size_t TestMatrixProduct(std::size_t TSize1, std::size_t TSize2,
+int TestMatrixProduct(std::size_t TSize1, std::size_t TSize2,
     std::size_t TSecondSize1) {
     std::cout << "Testing A(" << TSize1 << "," << TSize2
               << ") X B(" << TSize2 << "," << TSecondSize1
@@ -67,7 +67,7 @@ std::size_t TestMatrixProduct(std::size_t TSize1, std::size_t TSize2,
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
 
     // scalar product test
     number_of_failed_tests += TestMatrixScalarProduct(1,1);

--- a/test/test_dynamic_matrix_product.cpp
+++ b/test/test_dynamic_matrix_product.cpp
@@ -52,7 +52,7 @@ int TestMatrixProduct(std::size_t TSize1, std::size_t TSize2,
 
     for (std::size_t i = 0; i < b_matrix.size1(); i++)
         for (std::size_t j = 0; j < b_matrix.size2(); j++)
-            b_matrix(i, j) = i + j + 1;
+            b_matrix(i, j) = i + j + 1.00;
 
     c_matrix = a_matrix * b_matrix;
 

--- a/test/test_dynamic_matrix_resize.cpp
+++ b/test/test_dynamic_matrix_resize.cpp
@@ -1,7 +1,7 @@
 #include "amatrix.h"
 #include "checks.h"
 
-std::size_t TestDynamicMatrixResize(std::size_t Size1, std::size_t Size2) {
+int TestDynamicMatrixResize(std::size_t Size1, std::size_t Size2) {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(0,0);
     a_matrix.resize(Size1, Size2);
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
@@ -16,7 +16,7 @@ std::size_t TestDynamicMatrixResize(std::size_t Size1, std::size_t Size2) {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestDynamicMatrixResize(1, 1);
 
     number_of_failed_tests += TestDynamicMatrixResize(1, 2);

--- a/test/test_dynamic_matrix_scale_and_add.cpp
+++ b/test/test_dynamic_matrix_scale_and_add.cpp
@@ -1,7 +1,7 @@
 #include "amatrix.h"
 #include "checks.h"
 
-std::size_t TestMatrixScaleAndAdd(std::size_t TSize1, std::size_t TSize2) {
+int TestMatrixScaleAndAdd(std::size_t TSize1, std::size_t TSize2) {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(TSize1, TSize2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> b_matrix(TSize1, TSize2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> c_matrix(TSize1, TSize2);
@@ -20,7 +20,7 @@ std::size_t TestMatrixScaleAndAdd(std::size_t TSize1, std::size_t TSize2) {
     return 0;  // not failed
 }
 
-std::size_t TestMatrixScaleAndAddEqual(std::size_t TSize1, std::size_t TSize2) {
+int TestMatrixScaleAndAddEqual(std::size_t TSize1, std::size_t TSize2) {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(TSize1, TSize2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> b_matrix(TSize1, TSize2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> c_matrix(TSize1, TSize2);
@@ -40,7 +40,7 @@ std::size_t TestMatrixScaleAndAddEqual(std::size_t TSize1, std::size_t TSize2) {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
 	number_of_failed_tests += TestMatrixScaleAndAdd(1,1);
 
 	number_of_failed_tests += TestMatrixScaleAndAdd(1,2);

--- a/test/test_dynamic_matrix_swap.cpp
+++ b/test/test_dynamic_matrix_swap.cpp
@@ -1,7 +1,7 @@
 #include "amatrix.h"
 #include "checks.h"
 
-std::size_t TestMatrixSwap(std::size_t Size1, std::size_t Size2) {
+int TestMatrixSwap(std::size_t Size1, std::size_t Size2) {
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> a_matrix(Size1, Size2);
     AMatrix::Matrix<double, AMatrix::dynamic, AMatrix::dynamic> b_matrix(Size1, Size2);
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
@@ -22,7 +22,7 @@ std::size_t TestMatrixSwap(std::size_t Size1, std::size_t Size2) {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
 	number_of_failed_tests += TestMatrixSwap(1,1);
 
 	number_of_failed_tests += TestMatrixSwap(1,2);

--- a/test/test_dynamic_matrix_transpose.cpp
+++ b/test/test_dynamic_matrix_transpose.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template<std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixTranspose() {
+int TestMatrixTranspose() {
 	AMatrix::Matrix<double, AMatrix::dynamic,AMatrix::dynamic> a_matrix(TSize1,TSize2);
 	double b = 0;
 	for (std::size_t i = 0; i < a_matrix.size1(); i++)
@@ -21,7 +21,7 @@ std::size_t TestMatrixTranspose() {
 
 template <std::size_t TSize1, std::size_t TSize2,
     std::size_t NumberOfSecondRows>
-std::size_t TestMatrixTransposeProduct() {
+int TestMatrixTransposeProduct() {
     std::cout << "Testing A(" << TSize1 << "," << TSize2
               << ") X B(" << TSize2 << "," << NumberOfSecondRows
               << ") ";
@@ -53,7 +53,7 @@ std::size_t TestMatrixTransposeProduct() {
 
 int main()
 {
-	std::size_t number_of_failed_tests = 0;
+	int number_of_failed_tests = 0;
 	number_of_failed_tests += TestMatrixTranspose<1,1>();
 
 	number_of_failed_tests += TestMatrixTranspose<1,2>();

--- a/test/test_dynamic_matrix_transpose.cpp
+++ b/test/test_dynamic_matrix_transpose.cpp
@@ -37,7 +37,7 @@ int TestMatrixTransposeProduct() {
 
     for (std::size_t i = 0; i < b_matrix.size1(); i++)
         for (std::size_t j = 0; j < b_matrix.size2(); j++)
-            b_matrix(i, j) = i + j + 1;
+            b_matrix(i, j) = i + j + 1.00;
 
     c_matrix = a_matrix * b_matrix.transpose();
 

--- a/test/test_matrix_access.cpp
+++ b/test/test_matrix_access.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixAcess() {
+int TestMatrixAcess() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
         for (std::size_t j = 0; j < a_matrix.size2(); j++)
@@ -16,7 +16,7 @@ std::size_t TestMatrixAcess() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixAcess<1, 1>();
 
     number_of_failed_tests += TestMatrixAcess<1, 2>();

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -94,6 +94,33 @@ int TestMatrixRowCheckAliasing() {
     return 0;  // not failed
 }
 
+template <std::size_t TSize1, std::size_t TSize2>
+int TestMatrixColumnCheckAliasing() {
+    AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
+    a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
+
+    AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
+    b_matrix = a_matrix;
+
+    // Note: without this print the optimizer will take out a_matrix and b_matrix allocation resuting in test failure
+    std::cout << "Check overlapping of a_matrix.data() " << a_matrix.data()
+              << " and b_matrix.data() " << b_matrix.data() << std::endl;
+
+    for (std::size_t i = 1; i < a_matrix.size(); i++) {
+        AMATRIX_CHECK(a_matrix.col(i).check_aliasing(
+            a_matrix.data(), a_matrix.data() + a_matrix.size()));
+
+        AMATRIX_CHECK_EQUAL(b_matrix.col(i).check_aliasing(a_matrix.data(),
+                                a_matrix.data() + a_matrix.size()),
+            false);
+        AMATRIX_CHECK_EQUAL(a_matrix.col(i).check_aliasing(b_matrix.data(),
+                                b_matrix.data() + b_matrix.size()),
+            false);
+    }
+
+    return 0;  // not failed
+}
+
 int main() {
     int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixCheckAliasing<1, 1>();
@@ -109,18 +136,27 @@ int main() {
     number_of_failed_tests += TestMatrixCheckAliasing<2, 3>();
     number_of_failed_tests += TestMatrixCheckAliasing<3, 3>();
 
-    number_of_failed_tests += TestTransposeCheckAliasing<1, 1>();
-								  
-    number_of_failed_tests += TestTransposeCheckAliasing<1, 2>();
-    number_of_failed_tests += TestTransposeCheckAliasing<2, 1>();
-    number_of_failed_tests += TestTransposeCheckAliasing<2, 2>();
-								  
-    number_of_failed_tests += TestTransposeCheckAliasing<3, 1>();
-    number_of_failed_tests += TestTransposeCheckAliasing<3, 2>();
-    number_of_failed_tests += TestTransposeCheckAliasing<3, 3>();
-    number_of_failed_tests += TestTransposeCheckAliasing<1, 3>();
-    number_of_failed_tests += TestTransposeCheckAliasing<2, 3>();
-    number_of_failed_tests += TestTransposeCheckAliasing<3, 3>();
+    number_of_failed_tests += TestMatrixRowCheckAliasing<1, 1>();
+    number_of_failed_tests += TestMatrixRowCheckAliasing<1, 2>();
+    number_of_failed_tests += TestMatrixRowCheckAliasing<2, 1>();
+    number_of_failed_tests += TestMatrixRowCheckAliasing<2, 2>();
+    number_of_failed_tests += TestMatrixRowCheckAliasing<3, 1>();
+    number_of_failed_tests += TestMatrixRowCheckAliasing<3, 2>();
+    number_of_failed_tests += TestMatrixRowCheckAliasing<3, 3>();
+    number_of_failed_tests += TestMatrixRowCheckAliasing<1, 3>();
+    number_of_failed_tests += TestMatrixRowCheckAliasing<2, 3>();
+    number_of_failed_tests += TestMatrixRowCheckAliasing<3, 3>();
+
+    number_of_failed_tests += TestMatrixColumnCheckAliasing<1, 1>();
+    number_of_failed_tests += TestMatrixColumnCheckAliasing<1, 2>();
+    number_of_failed_tests += TestMatrixColumnCheckAliasing<2, 1>();
+    number_of_failed_tests += TestMatrixColumnCheckAliasing<2, 2>();
+    number_of_failed_tests += TestMatrixColumnCheckAliasing<3, 1>();
+    number_of_failed_tests += TestMatrixColumnCheckAliasing<3, 2>();
+    number_of_failed_tests += TestMatrixColumnCheckAliasing<3, 3>();
+    number_of_failed_tests += TestMatrixColumnCheckAliasing<1, 3>();
+    number_of_failed_tests += TestMatrixColumnCheckAliasing<2, 3>();
+    number_of_failed_tests += TestMatrixColumnCheckAliasing<3, 3>();
 
     std::cout << number_of_failed_tests << "tests failed" << std::endl;
 

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -285,7 +285,7 @@ int TestUnaryMinusExpressionCheckAliasing() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-int TestScalarProductExpressionCheckAliasing() {
+int TestScalarDivisionExpressionCheckAliasing() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
 
@@ -294,6 +294,31 @@ int TestScalarProductExpressionCheckAliasing() {
     b_matrix = a_matrix;
 
     auto a_scalar = 2.00 * a_matrix;
+
+    // Note: without this print the optimizer will take out a_matrix and b_matrix allocation resuting in test failure
+    std::cout << "Check overlapping of a_matrix.data() " << a_matrix.data()
+              << " and b_matrix.data() " << b_matrix.data() << std::endl;
+
+    AMATRIX_CHECK(a_scalar.check_aliasing(
+        a_matrix.data(), a_matrix.data() + a_matrix.size()));
+
+    AMATRIX_CHECK_EQUAL(a_scalar.check_aliasing(
+                            b_matrix.data(), b_matrix.data() + b_matrix.size()),
+        false);
+
+    return 0;  // not failed
+}
+
+template <std::size_t TSize1, std::size_t TSize2>
+int TestScalarProductExpressionCheckAliasing() {
+    AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
+    a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
+
+    AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
+
+    b_matrix = a_matrix;
+
+    auto a_scalar = a_matrix / 2.00;
 
     // Note: without this print the optimizer will take out a_matrix and b_matrix allocation resuting in test failure
     std::cout << "Check overlapping of a_matrix.data() " << a_matrix.data()
@@ -419,6 +444,17 @@ int main() {
     number_of_failed_tests += TestScalarProductExpressionCheckAliasing<1, 3>();
     number_of_failed_tests += TestScalarProductExpressionCheckAliasing<2, 3>();
     number_of_failed_tests += TestScalarProductExpressionCheckAliasing<3, 3>();
+
+    number_of_failed_tests += TestScalarDivisionExpressionCheckAliasing<1, 1>();
+    number_of_failed_tests += TestScalarDivisionExpressionCheckAliasing<1, 2>();
+    number_of_failed_tests += TestScalarDivisionExpressionCheckAliasing<2, 1>();
+    number_of_failed_tests += TestScalarDivisionExpressionCheckAliasing<2, 2>();
+    number_of_failed_tests += TestScalarDivisionExpressionCheckAliasing<3, 1>();
+    number_of_failed_tests += TestScalarDivisionExpressionCheckAliasing<3, 2>();
+    number_of_failed_tests += TestScalarDivisionExpressionCheckAliasing<3, 3>();
+    number_of_failed_tests += TestScalarDivisionExpressionCheckAliasing<1, 3>();
+    number_of_failed_tests += TestScalarDivisionExpressionCheckAliasing<2, 3>();
+    number_of_failed_tests += TestScalarDivisionExpressionCheckAliasing<3, 3>();
 
 	std::cout << number_of_failed_tests << "tests failed" << std::endl;
 

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -2,15 +2,20 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestTransposeCheckAliasing() {
+std::size_t TestMatrixCheckAliasing() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
 
     AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
-    b_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
+    b_matrix = a_matrix;
+
+	// Note: without this print the optimizer will take out a_matrix and b_matrix allocation resuting in test failure
+    std::cout << "Check overlapping of a_matrix.data() " << a_matrix.data()
+              << " and b_matrix.data() " << b_matrix.data() << std::endl;
 
     AMATRIX_CHECK(a_matrix.check_aliasing(
         a_matrix.data(), a_matrix.data() + a_matrix.size()));
+
 
     AMATRIX_CHECK_EQUAL(b_matrix.check_aliasing(
                             a_matrix.data(), a_matrix.data() + a_matrix.size()),
@@ -30,12 +35,16 @@ std::size_t TestTransposeCheckAliasing() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixCheckAliasing() {
+std::size_t TestTransposeCheckAliasing() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
 
     AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
-    b_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
+    b_matrix = a_matrix;
+
+	// Note: without this print the optimizer will take out a_matrix and b_matrix allocation resuting in test failure
+    std::cout << "Check overlapping of a_matrix.data() " << a_matrix.data()
+              << " and b_matrix.data() " << b_matrix.data() << std::endl;
 
     AMATRIX_CHECK(a_matrix.transpose().check_aliasing(
         a_matrix.data(), a_matrix.data() + a_matrix.size()));

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixCheckAliasing() {
+int TestMatrixCheckAliasing() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
 
@@ -35,7 +35,7 @@ std::size_t TestMatrixCheckAliasing() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestTransposeCheckAliasing() {
+int TestTransposeCheckAliasing() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
 
@@ -68,7 +68,7 @@ std::size_t TestTransposeCheckAliasing() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixCheckAliasing<1, 1>();
 
     number_of_failed_tests += TestMatrixCheckAliasing<1, 2>();

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -284,6 +284,31 @@ int TestUnaryMinusExpressionCheckAliasing() {
     return 0;  // not failed
 }
 
+template <std::size_t TSize1, std::size_t TSize2>
+int TestScalarProductExpressionCheckAliasing() {
+    AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
+    a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
+
+    AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
+
+    b_matrix = a_matrix;
+
+    auto a_scalar = 2.00 * a_matrix;
+
+    // Note: without this print the optimizer will take out a_matrix and b_matrix allocation resuting in test failure
+    std::cout << "Check overlapping of a_matrix.data() " << a_matrix.data()
+              << " and b_matrix.data() " << b_matrix.data() << std::endl;
+
+    AMATRIX_CHECK(a_scalar.check_aliasing(
+        a_matrix.data(), a_matrix.data() + a_matrix.size()));
+
+    AMATRIX_CHECK_EQUAL(a_scalar.check_aliasing(
+                            b_matrix.data(), b_matrix.data() + b_matrix.size()),
+        false);
+
+    return 0;  // not failed
+}
+
 int main() {
     int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixCheckAliasing<1, 1>();
@@ -383,6 +408,17 @@ int main() {
     number_of_failed_tests += TestUnaryMinusExpressionCheckAliasing<1, 3>();
     number_of_failed_tests += TestUnaryMinusExpressionCheckAliasing<2, 3>();
     number_of_failed_tests += TestUnaryMinusExpressionCheckAliasing<3, 3>();
+
+    number_of_failed_tests += TestScalarProductExpressionCheckAliasing<1, 1>();
+    number_of_failed_tests += TestScalarProductExpressionCheckAliasing<1, 2>();
+    number_of_failed_tests += TestScalarProductExpressionCheckAliasing<2, 1>();
+    number_of_failed_tests += TestScalarProductExpressionCheckAliasing<2, 2>();
+    number_of_failed_tests += TestScalarProductExpressionCheckAliasing<3, 1>();
+    number_of_failed_tests += TestScalarProductExpressionCheckAliasing<3, 2>();
+    number_of_failed_tests += TestScalarProductExpressionCheckAliasing<3, 3>();
+    number_of_failed_tests += TestScalarProductExpressionCheckAliasing<1, 3>();
+    number_of_failed_tests += TestScalarProductExpressionCheckAliasing<2, 3>();
+    number_of_failed_tests += TestScalarProductExpressionCheckAliasing<3, 3>();
 
 	std::cout << number_of_failed_tests << "tests failed" << std::endl;
 

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -183,6 +183,17 @@ int TestSubVectorCheckAliasing() {
     return 0;  // not failed
 }
 
+template <std::size_t TSize1, std::size_t TSize2>
+int TestZeroCheckAliasing() {
+    AMatrix::ZeroMatrix<double> zero_matrix(TSize1, TSize2);
+    AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
+    double* a_pointer = a_matrix.data();
+    AMATRIX_CHECK_EQUAL(zero_matrix.check_aliasing(a_pointer - 1024, a_pointer + 1024),
+            false);
+
+    return 0;  // not failed
+}
+
 int main() {
     int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixCheckAliasing<1, 1>();
@@ -230,6 +241,21 @@ int main() {
     number_of_failed_tests += TestSubMatrixCheckAliasing<1, 3>();
     number_of_failed_tests += TestSubMatrixCheckAliasing<2, 3>();
     number_of_failed_tests += TestSubMatrixCheckAliasing<3, 3>();
+
+    number_of_failed_tests += TestSubVectorCheckAliasing<1>();
+    number_of_failed_tests += TestSubVectorCheckAliasing<2>();
+    number_of_failed_tests += TestSubVectorCheckAliasing<3>();
+
+    number_of_failed_tests += TestZeroCheckAliasing<1, 1>();
+    number_of_failed_tests += TestZeroCheckAliasing<1, 2>();
+    number_of_failed_tests += TestZeroCheckAliasing<2, 1>();
+    number_of_failed_tests += TestZeroCheckAliasing<2, 2>();
+    number_of_failed_tests += TestZeroCheckAliasing<3, 1>();
+    number_of_failed_tests += TestZeroCheckAliasing<3, 2>();
+    number_of_failed_tests += TestZeroCheckAliasing<3, 3>();
+    number_of_failed_tests += TestZeroCheckAliasing<1, 3>();
+    number_of_failed_tests += TestZeroCheckAliasing<2, 3>();
+    number_of_failed_tests += TestZeroCheckAliasing<3, 3>();
 
     std::cout << number_of_failed_tests << "tests failed" << std::endl;
 

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -154,6 +154,35 @@ int TestSubMatrixCheckAliasing() {
     return 0;  // not failed
 }
 
+template <std::size_t TSize>
+int TestSubVectorCheckAliasing() {
+    AMatrix::Vector<double, TSize> a_vector(
+        AMatrix::ZeroMatrix<double>(TSize, 1));
+    AMatrix::Vector<double, TSize> b_vector(
+        AMatrix::ZeroMatrix<double>(TSize, 1));
+
+    std::size_t sub_size = (TSize > 1) ? TSize - 1 : 1;
+    std::size_t sub_index = (TSize > 1) ? 1 : 0;
+
+    AMatrix::SubVector<AMatrix::Vector<double, TSize>> sub_vector(
+        a_vector, sub_index, sub_size);
+
+    // Note: without this print the optimizer will take out a_matrix and b_matrix allocation resuting in test failure
+    std::cout << "Check overlapping of a_vector.data() " << a_vector.data()
+              << " and b_vector.data() " << b_vector.data() << std::endl;
+
+    for (std::size_t i = 1; i < a_vector.size(); i++) {
+        AMATRIX_CHECK(sub_vector.check_aliasing(
+            a_vector.data(), a_vector.data() + a_vector.size()));
+
+        AMATRIX_CHECK_EQUAL(sub_vector.check_aliasing(b_vector.data(),
+                                b_vector.data() + b_vector.size()),
+            false);
+    }
+
+    return 0;  // not failed
+}
+
 int main() {
     int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixCheckAliasing<1, 1>();

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -233,6 +233,32 @@ int TestSumExpressionCheckAliasing() {
     return 0;  // not failed
 }
 
+template <std::size_t TSize1, std::size_t TSize2>
+int TestMinusExpressionCheckAliasing() {
+    AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
+    a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
+
+    AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
+
+    b_matrix = a_matrix;
+
+    auto a_minus_b = a_matrix - b_matrix;
+    auto b_minus_b = b_matrix - b_matrix;
+
+    // Note: without this print the optimizer will take out a_matrix and b_matrix allocation resuting in test failure
+    std::cout << "Check overlapping of a_matrix.data() " << a_matrix.data()
+              << " and b_matrix.data() " << b_matrix.data() << std::endl;
+
+    AMATRIX_CHECK(a_minus_b.check_aliasing(
+        a_matrix.data(), a_matrix.data() + a_matrix.size()));
+
+    AMATRIX_CHECK_EQUAL(b_minus_b.check_aliasing(
+                            a_matrix.data(), a_matrix.data() + a_matrix.size()),
+        false);
+
+    return 0;  // not failed
+}
+
 int main() {
     int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixCheckAliasing<1, 1>();
@@ -311,6 +337,16 @@ int main() {
     number_of_failed_tests += TestSumExpressionCheckAliasing<2, 3>();
     number_of_failed_tests += TestSumExpressionCheckAliasing<3, 3>();
 
+    number_of_failed_tests += TestMinusExpressionCheckAliasing<1, 1>();
+    number_of_failed_tests += TestMinusExpressionCheckAliasing<1, 2>();
+    number_of_failed_tests += TestMinusExpressionCheckAliasing<2, 1>();
+    number_of_failed_tests += TestMinusExpressionCheckAliasing<2, 2>();
+    number_of_failed_tests += TestMinusExpressionCheckAliasing<3, 1>();
+    number_of_failed_tests += TestMinusExpressionCheckAliasing<3, 2>();
+    number_of_failed_tests += TestMinusExpressionCheckAliasing<3, 3>();
+    number_of_failed_tests += TestMinusExpressionCheckAliasing<1, 3>();
+    number_of_failed_tests += TestMinusExpressionCheckAliasing<2, 3>();
+    number_of_failed_tests += TestMinusExpressionCheckAliasing<3, 3>();
     std::cout << number_of_failed_tests << "tests failed" << std::endl;
 
     return number_of_failed_tests;

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -167,7 +167,7 @@ int TestSubVectorCheckAliasing() {
     AMatrix::SubVector<AMatrix::Vector<double, TSize>> sub_vector(
         a_vector, sub_index, sub_size);
 
-    // Note: without this print the optimizer will take out a_matrix and b_matrix allocation resuting in test failure
+    // Note: without this print the optimizer will take out a_vector and b_vector allocation resuting in test failure
     std::cout << "Check overlapping of a_vector.data() " << a_vector.data()
               << " and b_vector.data() " << b_vector.data() << std::endl;
 
@@ -334,6 +334,30 @@ int TestScalarProductExpressionCheckAliasing() {
     return 0;  // not failed
 }
 
+template <std::size_t TSize>
+int TestOuterProductExpressionCheckAliasing() {
+    AMatrix::Vector<double, TSize> a_vector(
+        AMatrix::ZeroMatrix<double>(TSize, 1));
+    AMatrix::Vector<double, TSize> b_vector(
+        AMatrix::ZeroMatrix<double>(TSize, 1));
+
+    auto a_prod_b = OuterProduct(a_vector, b_vector);
+    auto b_prod_b = OuterProduct(b_vector, b_vector);
+
+    // Note: without this print the optimizer will take out a_vector and b_vector allocation resuting in test failure
+    std::cout << "Check overlapping of a_vector.data() " << a_vector.data()
+              << " and b_vector.data() " << b_vector.data() << std::endl;
+
+    AMATRIX_CHECK(a_prod_b.check_aliasing(
+        a_vector.data(), a_vector.data() + a_vector.size()));
+
+    AMATRIX_CHECK_EQUAL(b_prod_b.check_aliasing(
+                            a_vector.data(), a_vector.data() + a_vector.size()),
+        false);
+
+    return 0;  // not failed
+}
+
 int main() {
     int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixCheckAliasing<1, 1>();
@@ -455,6 +479,10 @@ int main() {
     number_of_failed_tests += TestScalarDivisionExpressionCheckAliasing<1, 3>();
     number_of_failed_tests += TestScalarDivisionExpressionCheckAliasing<2, 3>();
     number_of_failed_tests += TestScalarDivisionExpressionCheckAliasing<3, 3>();
+
+    number_of_failed_tests += TestOuterProductExpressionCheckAliasing<1>();
+    number_of_failed_tests += TestOuterProductExpressionCheckAliasing<2>();
+    number_of_failed_tests += TestOuterProductExpressionCheckAliasing<3>();
 
 	std::cout << number_of_failed_tests << "tests failed" << std::endl;
 

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -121,6 +121,39 @@ int TestMatrixColumnCheckAliasing() {
     return 0;  // not failed
 }
 
+template <std::size_t TSize1, std::size_t TSize2>
+int TestSubMatrixCheckAliasing() {
+    AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
+    a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
+    AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
+    b_matrix = a_matrix;
+
+
+    std::size_t sub_size1 = (TSize1 > 1) ? TSize1 - 1 : 1;
+    std::size_t sub_size2 = (TSize2 > 1) ? TSize2 - 1 : 1;
+
+    std::size_t sub_index1 = (TSize1 > 1) ? 1 : 0;
+    std::size_t sub_index2 = (TSize2 > 1) ? 1 : 0;
+
+    AMatrix::SubMatrix<AMatrix::Matrix<double, TSize1, TSize2>> sub_matrix(
+        a_matrix, sub_index1, sub_index2, sub_size1, sub_size2);
+
+    // Note: without this print the optimizer will take out a_matrix and b_matrix allocation resuting in test failure
+    std::cout << "Check overlapping of a_matrix.data() " << a_matrix.data()
+              << " and b_matrix.data() " << b_matrix.data() << std::endl;
+
+	for (std::size_t i = 1; i < a_matrix.size(); i++) {
+        AMATRIX_CHECK(sub_matrix.check_aliasing(
+            a_matrix.data(), a_matrix.data() + a_matrix.size()));
+
+        AMATRIX_CHECK_EQUAL(sub_matrix.check_aliasing(b_matrix.data(),
+                                b_matrix.data() + b_matrix.size()),
+            false);
+    }
+
+    return 0;  // not failed
+}
+
 int main() {
     int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixCheckAliasing<1, 1>();
@@ -157,6 +190,17 @@ int main() {
     number_of_failed_tests += TestMatrixColumnCheckAliasing<1, 3>();
     number_of_failed_tests += TestMatrixColumnCheckAliasing<2, 3>();
     number_of_failed_tests += TestMatrixColumnCheckAliasing<3, 3>();
+
+    number_of_failed_tests += TestSubMatrixCheckAliasing<1, 1>();
+    number_of_failed_tests += TestSubMatrixCheckAliasing<1, 2>();
+    number_of_failed_tests += TestSubMatrixCheckAliasing<2, 1>();
+    number_of_failed_tests += TestSubMatrixCheckAliasing<2, 2>();
+    number_of_failed_tests += TestSubMatrixCheckAliasing<3, 1>();
+    number_of_failed_tests += TestSubMatrixCheckAliasing<3, 2>();
+    number_of_failed_tests += TestSubMatrixCheckAliasing<3, 3>();
+    number_of_failed_tests += TestSubMatrixCheckAliasing<1, 3>();
+    number_of_failed_tests += TestSubMatrixCheckAliasing<2, 3>();
+    number_of_failed_tests += TestSubMatrixCheckAliasing<3, 3>();
 
     std::cout << number_of_failed_tests << "tests failed" << std::endl;
 

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -206,6 +206,33 @@ int TestIdentityMatrixCheckAliasing() {
     return 0;  // not failed
 }
 
+
+template <std::size_t TSize1, std::size_t TSize2>
+int TestSumExpressionCheckAliasing() {
+    AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
+    a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
+
+    AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
+ 
+    b_matrix = a_matrix;
+
+	auto a_plus_b = a_matrix + b_matrix;
+    auto b_plus_b = b_matrix + b_matrix;
+
+    // Note: without this print the optimizer will take out a_matrix and b_matrix allocation resuting in test failure
+    std::cout << "Check overlapping of a_matrix.data() " << a_matrix.data()
+              << " and b_matrix.data() " << b_matrix.data() << std::endl;
+
+    AMATRIX_CHECK(a_plus_b.check_aliasing(
+        a_matrix.data(), a_matrix.data() + a_matrix.size()));
+
+    AMATRIX_CHECK_EQUAL(b_plus_b.check_aliasing(
+                            a_matrix.data(), a_matrix.data() + a_matrix.size()),
+        false);
+
+    return 0;  // not failed
+}
+
 int main() {
     int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixCheckAliasing<1, 1>();
@@ -272,6 +299,17 @@ int main() {
     number_of_failed_tests += TestIdentityMatrixCheckAliasing<1>();
     number_of_failed_tests += TestIdentityMatrixCheckAliasing<2>();
     number_of_failed_tests += TestIdentityMatrixCheckAliasing<3>();
+
+    number_of_failed_tests += TestSumExpressionCheckAliasing<1, 1>();
+    number_of_failed_tests += TestSumExpressionCheckAliasing<1, 2>();
+    number_of_failed_tests += TestSumExpressionCheckAliasing<2, 1>();
+    number_of_failed_tests += TestSumExpressionCheckAliasing<2, 2>();
+    number_of_failed_tests += TestSumExpressionCheckAliasing<3, 1>();
+    number_of_failed_tests += TestSumExpressionCheckAliasing<3, 2>();
+    number_of_failed_tests += TestSumExpressionCheckAliasing<3, 3>();
+    number_of_failed_tests += TestSumExpressionCheckAliasing<1, 3>();
+    number_of_failed_tests += TestSumExpressionCheckAliasing<2, 3>();
+    number_of_failed_tests += TestSumExpressionCheckAliasing<3, 3>();
 
     std::cout << number_of_failed_tests << "tests failed" << std::endl;
 

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -184,12 +184,24 @@ int TestSubVectorCheckAliasing() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-int TestZeroCheckAliasing() {
+int TestZeroMatrixCheckAliasing() {
     AMatrix::ZeroMatrix<double> zero_matrix(TSize1, TSize2);
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     double* a_pointer = a_matrix.data();
-    AMATRIX_CHECK_EQUAL(zero_matrix.check_aliasing(a_pointer - 1024, a_pointer + 1024),
-            false);
+    AMATRIX_CHECK_EQUAL(
+        zero_matrix.check_aliasing(a_pointer - 1024, a_pointer + 1024), false);
+
+    return 0;  // not failed
+}
+
+template <std::size_t TSize>
+int TestIdentityMatrixCheckAliasing() {
+    AMatrix::IdentityMatrix<double> identity_matrix(TSize);
+    AMatrix::Matrix<double, TSize, TSize> a_matrix;
+    double* a_pointer = a_matrix.data();
+    AMATRIX_CHECK_EQUAL(
+        identity_matrix.check_aliasing(a_pointer - 1024, a_pointer + 1024),
+        false);
 
     return 0;  // not failed
 }
@@ -246,16 +258,20 @@ int main() {
     number_of_failed_tests += TestSubVectorCheckAliasing<2>();
     number_of_failed_tests += TestSubVectorCheckAliasing<3>();
 
-    number_of_failed_tests += TestZeroCheckAliasing<1, 1>();
-    number_of_failed_tests += TestZeroCheckAliasing<1, 2>();
-    number_of_failed_tests += TestZeroCheckAliasing<2, 1>();
-    number_of_failed_tests += TestZeroCheckAliasing<2, 2>();
-    number_of_failed_tests += TestZeroCheckAliasing<3, 1>();
-    number_of_failed_tests += TestZeroCheckAliasing<3, 2>();
-    number_of_failed_tests += TestZeroCheckAliasing<3, 3>();
-    number_of_failed_tests += TestZeroCheckAliasing<1, 3>();
-    number_of_failed_tests += TestZeroCheckAliasing<2, 3>();
-    number_of_failed_tests += TestZeroCheckAliasing<3, 3>();
+    number_of_failed_tests += TestZeroMatrixCheckAliasing<1, 1>();
+    number_of_failed_tests += TestZeroMatrixCheckAliasing<1, 2>();
+    number_of_failed_tests += TestZeroMatrixCheckAliasing<2, 1>();
+    number_of_failed_tests += TestZeroMatrixCheckAliasing<2, 2>();
+    number_of_failed_tests += TestZeroMatrixCheckAliasing<3, 1>();
+    number_of_failed_tests += TestZeroMatrixCheckAliasing<3, 2>();
+    number_of_failed_tests += TestZeroMatrixCheckAliasing<3, 3>();
+    number_of_failed_tests += TestZeroMatrixCheckAliasing<1, 3>();
+    number_of_failed_tests += TestZeroMatrixCheckAliasing<2, 3>();
+    number_of_failed_tests += TestZeroMatrixCheckAliasing<3, 3>();
+
+    number_of_failed_tests += TestIdentityMatrixCheckAliasing<1>();
+    number_of_failed_tests += TestIdentityMatrixCheckAliasing<2>();
+    number_of_failed_tests += TestIdentityMatrixCheckAliasing<3>();
 
     std::cout << number_of_failed_tests << "tests failed" << std::endl;
 

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixCheckAliasing() {
+std::size_t TestTransposeCheckAliasing() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
 
@@ -29,21 +29,62 @@ std::size_t TestMatrixCheckAliasing() {
     return 0;  // not failed
 }
 
+template <std::size_t TSize1, std::size_t TSize2>
+std::size_t TestMatrixCheckAliasing() {
+    AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
+    a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
+
+    AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
+    b_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
+
+    AMATRIX_CHECK(a_matrix.transpose().check_aliasing(
+        a_matrix.data(), a_matrix.data() + a_matrix.size()));
+
+    AMATRIX_CHECK_EQUAL(b_matrix.transpose().check_aliasing(
+                            a_matrix.data(), a_matrix.data() + a_matrix.size()),
+        false);
+    AMATRIX_CHECK_EQUAL(a_matrix.transpose().check_aliasing(
+                            b_matrix.data(), b_matrix.data() + b_matrix.size()),
+        false);
+
+    for (std::size_t i = 1; i < a_matrix.size(); i++) {
+        auto begin = a_matrix.data() - a_matrix.size() + i;
+        AMATRIX_CHECK(
+            a_matrix.transpose().check_aliasing(begin, begin + a_matrix.size()));
+    }
+    AMATRIX_CHECK(a_matrix.transpose().check_aliasing(
+        a_matrix.data() - 1, a_matrix.data() + a_matrix.size()));
+
+    return 0;  // not failed
+}
 
 int main() {
     std::size_t number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixCheckAliasing<1, 1>();
-							  
+
     number_of_failed_tests += TestMatrixCheckAliasing<1, 2>();
     number_of_failed_tests += TestMatrixCheckAliasing<2, 1>();
     number_of_failed_tests += TestMatrixCheckAliasing<2, 2>();
-							  
+
     number_of_failed_tests += TestMatrixCheckAliasing<3, 1>();
     number_of_failed_tests += TestMatrixCheckAliasing<3, 2>();
     number_of_failed_tests += TestMatrixCheckAliasing<3, 3>();
     number_of_failed_tests += TestMatrixCheckAliasing<1, 3>();
     number_of_failed_tests += TestMatrixCheckAliasing<2, 3>();
     number_of_failed_tests += TestMatrixCheckAliasing<3, 3>();
+
+    number_of_failed_tests += TestTransposeCheckAliasing<1, 1>();
+								  
+    number_of_failed_tests += TestTransposeCheckAliasing<1, 2>();
+    number_of_failed_tests += TestTransposeCheckAliasing<2, 1>();
+    number_of_failed_tests += TestTransposeCheckAliasing<2, 2>();
+								  
+    number_of_failed_tests += TestTransposeCheckAliasing<3, 1>();
+    number_of_failed_tests += TestTransposeCheckAliasing<3, 2>();
+    number_of_failed_tests += TestTransposeCheckAliasing<3, 3>();
+    number_of_failed_tests += TestTransposeCheckAliasing<1, 3>();
+    number_of_failed_tests += TestTransposeCheckAliasing<2, 3>();
+    number_of_failed_tests += TestTransposeCheckAliasing<3, 3>();
 
     std::cout << number_of_failed_tests << "tests failed" << std::endl;
 

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -107,13 +107,13 @@ int TestMatrixColumnCheckAliasing() {
               << " and b_matrix.data() " << b_matrix.data() << std::endl;
 
     for (std::size_t i = 1; i < a_matrix.size(); i++) {
-        AMATRIX_CHECK(a_matrix.col(i).check_aliasing(
+        AMATRIX_CHECK(a_matrix.column(i).check_aliasing(
             a_matrix.data(), a_matrix.data() + a_matrix.size()));
 
-        AMATRIX_CHECK_EQUAL(b_matrix.col(i).check_aliasing(a_matrix.data(),
+        AMATRIX_CHECK_EQUAL(b_matrix.column(i).check_aliasing(a_matrix.data(),
                                 a_matrix.data() + a_matrix.size()),
             false);
-        AMATRIX_CHECK_EQUAL(a_matrix.col(i).check_aliasing(b_matrix.data(),
+        AMATRIX_CHECK_EQUAL(a_matrix.column(i).check_aliasing(b_matrix.data(),
                                 b_matrix.data() + b_matrix.size()),
             false);
     }

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -1,0 +1,51 @@
+#include "amatrix.h"
+#include "checks.h"
+
+template <std::size_t TSize1, std::size_t TSize2>
+std::size_t TestMatrixCheckAliasing() {
+    AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
+    a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
+
+    AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
+    b_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
+
+    AMATRIX_CHECK(a_matrix.check_aliasing(
+        a_matrix.data(), a_matrix.data() + a_matrix.size()));
+
+    AMATRIX_CHECK_EQUAL(b_matrix.check_aliasing(
+                            a_matrix.data(), a_matrix.data() + a_matrix.size()),
+        false);
+    AMATRIX_CHECK_EQUAL(a_matrix.check_aliasing(
+                            b_matrix.data(), b_matrix.data() + b_matrix.size()),
+        false);
+
+    for (std::size_t i = 1; i < a_matrix.size(); i++) {
+            auto begin = a_matrix.data() - a_matrix.size() + i;
+        AMATRIX_CHECK(a_matrix.check_aliasing(begin, begin + a_matrix.size()));
+        }
+    AMATRIX_CHECK(a_matrix.check_aliasing(
+        a_matrix.data() - 1, a_matrix.data() + a_matrix.size()));
+
+    return 0;  // not failed
+}
+
+
+int main() {
+    std::size_t number_of_failed_tests = 0;
+    number_of_failed_tests += TestMatrixCheckAliasing<1, 1>();
+							  
+    number_of_failed_tests += TestMatrixCheckAliasing<1, 2>();
+    number_of_failed_tests += TestMatrixCheckAliasing<2, 1>();
+    number_of_failed_tests += TestMatrixCheckAliasing<2, 2>();
+							  
+    number_of_failed_tests += TestMatrixCheckAliasing<3, 1>();
+    number_of_failed_tests += TestMatrixCheckAliasing<3, 2>();
+    number_of_failed_tests += TestMatrixCheckAliasing<3, 3>();
+    number_of_failed_tests += TestMatrixCheckAliasing<1, 3>();
+    number_of_failed_tests += TestMatrixCheckAliasing<2, 3>();
+    number_of_failed_tests += TestMatrixCheckAliasing<3, 3>();
+
+    std::cout << number_of_failed_tests << "tests failed" << std::endl;
+
+    return number_of_failed_tests;
+}

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -259,6 +259,31 @@ int TestMinusExpressionCheckAliasing() {
     return 0;  // not failed
 }
 
+template <std::size_t TSize1, std::size_t TSize2>
+int TestUnaryMinusExpressionCheckAliasing() {
+    AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
+    a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
+
+    AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
+
+    b_matrix = a_matrix;
+
+    auto a_minus = - a_matrix;
+
+    // Note: without this print the optimizer will take out a_matrix and b_matrix allocation resuting in test failure
+    std::cout << "Check overlapping of a_matrix.data() " << a_matrix.data()
+              << " and b_matrix.data() " << b_matrix.data() << std::endl;
+
+    AMATRIX_CHECK(a_minus.check_aliasing(
+        a_matrix.data(), a_matrix.data() + a_matrix.size()));
+
+    AMATRIX_CHECK_EQUAL(a_minus.check_aliasing(
+                            b_matrix.data(), b_matrix.data() + b_matrix.size()),
+        false);
+
+    return 0;  // not failed
+}
+
 int main() {
     int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixCheckAliasing<1, 1>();
@@ -347,7 +372,19 @@ int main() {
     number_of_failed_tests += TestMinusExpressionCheckAliasing<1, 3>();
     number_of_failed_tests += TestMinusExpressionCheckAliasing<2, 3>();
     number_of_failed_tests += TestMinusExpressionCheckAliasing<3, 3>();
-    std::cout << number_of_failed_tests << "tests failed" << std::endl;
+
+    number_of_failed_tests += TestUnaryMinusExpressionCheckAliasing<1, 1>();
+    number_of_failed_tests += TestUnaryMinusExpressionCheckAliasing<1, 2>();
+    number_of_failed_tests += TestUnaryMinusExpressionCheckAliasing<2, 1>();
+    number_of_failed_tests += TestUnaryMinusExpressionCheckAliasing<2, 2>();
+    number_of_failed_tests += TestUnaryMinusExpressionCheckAliasing<3, 1>();
+    number_of_failed_tests += TestUnaryMinusExpressionCheckAliasing<3, 2>();
+    number_of_failed_tests += TestUnaryMinusExpressionCheckAliasing<3, 3>();
+    number_of_failed_tests += TestUnaryMinusExpressionCheckAliasing<1, 3>();
+    number_of_failed_tests += TestUnaryMinusExpressionCheckAliasing<2, 3>();
+    number_of_failed_tests += TestUnaryMinusExpressionCheckAliasing<3, 3>();
+
+	std::cout << number_of_failed_tests << "tests failed" << std::endl;
 
     return number_of_failed_tests;
 }

--- a/test/test_matrix_aliasing.cpp
+++ b/test/test_matrix_aliasing.cpp
@@ -67,6 +67,33 @@ int TestTransposeCheckAliasing() {
     return 0;  // not failed
 }
 
+template <std::size_t TSize1, std::size_t TSize2>
+int TestMatrixRowCheckAliasing() {
+    AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
+    a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
+
+    AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
+    b_matrix = a_matrix;
+
+    // Note: without this print the optimizer will take out a_matrix and b_matrix allocation resuting in test failure
+    std::cout << "Check overlapping of a_matrix.data() " << a_matrix.data()
+              << " and b_matrix.data() " << b_matrix.data() << std::endl;
+
+	for (std::size_t i = 1; i < a_matrix.size(); i++) {
+        AMATRIX_CHECK(a_matrix.row(i).check_aliasing(
+            a_matrix.data(), a_matrix.data() + a_matrix.size()));
+
+        AMATRIX_CHECK_EQUAL(b_matrix.row(i).check_aliasing(a_matrix.data(),
+                                a_matrix.data() + a_matrix.size()),
+            false);
+        AMATRIX_CHECK_EQUAL(a_matrix.row(i).check_aliasing(b_matrix.data(),
+                                b_matrix.data() + b_matrix.size()),
+            false);
+    }
+
+    return 0;  // not failed
+}
+
 int main() {
     int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixCheckAliasing<1, 1>();

--- a/test/test_matrix_assign.cpp
+++ b/test/test_matrix_assign.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestZeroMatrixAssign() {
+int TestZeroMatrixAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     a_matrix = AMatrix::ZeroMatrix<double>(TSize1, TSize2);
 
@@ -14,7 +14,7 @@ std::size_t TestZeroMatrixAssign() {
 }
 
 template <std::size_t TSize>
-std::size_t TestIdentityMatrixAssign() {
+int TestIdentityMatrixAssign() {
     AMatrix::Matrix<double, TSize, TSize> a_matrix;
     a_matrix = AMatrix::IdentityMatrix<double>(TSize);
 
@@ -31,7 +31,7 @@ std::size_t TestIdentityMatrixAssign() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixAssign() {
+int TestMatrixAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
@@ -48,7 +48,7 @@ std::size_t TestMatrixAssign() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixExpressionAssign() {
+int TestMatrixExpressionAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
@@ -65,7 +65,7 @@ std::size_t TestMatrixExpressionAssign() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestZeroMatrixAssign<1, 1>();
 
     number_of_failed_tests += TestZeroMatrixAssign<1, 2>();

--- a/test/test_matrix_column.cpp
+++ b/test/test_matrix_column.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixColumnAcess() {
+int TestMatrixColumnAcess() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++) {
         for (std::size_t j = 0; j < a_matrix.size2(); j++)
@@ -23,7 +23,7 @@ std::size_t TestMatrixColumnAcess() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixColumnAssign() {
+int TestMatrixColumnAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t j = 0; j < a_matrix.size2(); j++) {
         AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_column_j =
@@ -61,7 +61,7 @@ std::size_t TestMatrixColumnAssign() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixColumnExpressionAssign() {
+int TestMatrixColumnExpressionAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t j = 0; j < a_matrix.size2(); j++) {
         AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_column_j =
@@ -82,7 +82,7 @@ std::size_t TestMatrixColumnExpressionAssign() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
 
     number_of_failed_tests += TestMatrixColumnAcess<1, 1>();
     number_of_failed_tests += TestMatrixColumnAcess<1, 2>();

--- a/test/test_matrix_column.cpp
+++ b/test/test_matrix_column.cpp
@@ -10,8 +10,7 @@ int TestMatrixColumnAcess() {
     }
 
     for (std::size_t j = 0; j < a_matrix.size2(); j++) {
-        const AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_column_j =
-            a_matrix.col(j);
+        const AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_column_j = a_matrix.column(j);
 
         for (std::size_t i = 0; i < a_matrix.size1(); i++) {
             AMATRIX_CHECK_EQUAL(a_column_j(i, 0), a_matrix(i, j));
@@ -26,8 +25,7 @@ template <std::size_t TSize1, std::size_t TSize2>
 int TestMatrixColumnAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t j = 0; j < a_matrix.size2(); j++) {
-        AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_column_j =
-            a_matrix.col(j);
+        AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_column_j = a_matrix.column(j);
         AMATRIX_CHECK_EQUAL(a_column_j.size(), TSize1);
         AMATRIX_CHECK_EQUAL(a_column_j.size1(), TSize1);
         AMATRIX_CHECK_EQUAL(a_column_j.size2(), 1);
@@ -43,7 +41,7 @@ int TestMatrixColumnAssign() {
 
     for (std::size_t j = 0; j < a_matrix.size2(); j++) {
         AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>>
-            a_column_j = a_matrix.col(j);
+            a_column_j = a_matrix.column(j);
         AMATRIX_CHECK_EQUAL(a_column_j.size(), TSize1);
         AMATRIX_CHECK_EQUAL(a_column_j.size1(), TSize1);
         AMATRIX_CHECK_EQUAL(a_column_j.size2(), 1);
@@ -64,8 +62,7 @@ template <std::size_t TSize1, std::size_t TSize2>
 int TestMatrixColumnExpressionAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t j = 0; j < a_matrix.size2(); j++) {
-        AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_column_j =
-            a_matrix.col(j);
+        AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_column_j = a_matrix.column(j);
         AMatrix::Matrix<double, 1, TSize1> b_vector;
         for (std::size_t i = 0; i < a_matrix.size1(); i++)
             b_vector[i] = 2.33 * i - 4.52 * j;

--- a/test/test_matrix_initialize.cpp
+++ b/test/test_matrix_initialize.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixInitializeToZero() {
+int TestMatrixInitializeToZero() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix(
         AMatrix::ZeroMatrix<double>(TSize1, TSize2));
 
@@ -13,7 +13,7 @@ std::size_t TestMatrixInitializeToZero() {
     return 0;  // not failed
 }
 
-std::size_t TestMatrixInitialize1() {
+int TestMatrixInitialize1() {
     AMatrix::Matrix<double, 1, 1> a_matrix{1.2};
 
     AMATRIX_CHECK_EQUAL(a_matrix(0, 0), 1.2);
@@ -21,7 +21,7 @@ std::size_t TestMatrixInitialize1() {
     return 0;  // not failed
 }
 
-std::size_t TestMatrixInitialize2() {
+int TestMatrixInitialize2() {
     AMatrix::Matrix<double, 1, 2> a_matrix{1.2, 2.3};
     AMatrix::Matrix<double, 2, 1> b_matrix{1.2, 
 										   2.3};
@@ -44,7 +44,7 @@ std::size_t TestMatrixInitialize2() {
     return 0;  // not failed
 }
 
-std::size_t TestMatrixInitialize3() {
+int TestMatrixInitialize3() {
     AMatrix::Matrix<double, 1, 3> a_matrix{1.2, 2.3, 3.4};
     AMatrix::Matrix<double, 3, 1> b_matrix{1.2, 
 										   2.3,
@@ -83,7 +83,7 @@ std::size_t TestMatrixInitialize3() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixInitializeToZero<1, 1>();
 
     number_of_failed_tests += TestMatrixInitializeToZero<1, 2>();

--- a/test/test_matrix_iterator.cpp
+++ b/test/test_matrix_iterator.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixIteratorAssign() {
+int TestMatrixIteratorAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     double memberwise_coeficient = 0.00;
     for (auto i = a_matrix.begin(); i != a_matrix.end(); i++)
@@ -19,7 +19,7 @@ std::size_t TestMatrixIteratorAssign() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixIteratorForwardBackward() {
+int TestMatrixIteratorForwardBackward() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     double memberwise_coeficient = 0.00;
 
@@ -46,7 +46,7 @@ std::size_t TestMatrixIteratorForwardBackward() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixIteratorArithmetic() {
+int TestMatrixIteratorArithmetic() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     double memberwise_coeficient = 0.00;
 
@@ -96,7 +96,7 @@ std::size_t TestMatrixIteratorArithmetic() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixForEachIteratorAssign() {
+int TestMatrixForEachIteratorAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     double memberwise_coeficient = 0.00;
 
@@ -113,7 +113,7 @@ std::size_t TestMatrixForEachIteratorAssign() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixInequality() {
+int TestMatrixInequality() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix(AMatrix::ZeroMatrix<double>(TSize1, TSize2));
 
     for(auto i = a_matrix.begin() ; i != a_matrix.end() ; i++){
@@ -133,7 +133,7 @@ std::size_t TestMatrixInequality() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixConstIterator() {
+int TestMatrixConstIterator() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     double memberwise_coeficient = 0.00;
 
@@ -151,7 +151,7 @@ std::size_t TestMatrixConstIterator() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixIteratorAssign<1, 1>();
 
     number_of_failed_tests += TestMatrixIteratorAssign<1, 2>();

--- a/test/test_matrix_iterator.cpp
+++ b/test/test_matrix_iterator.cpp
@@ -27,8 +27,8 @@ int TestMatrixIteratorForwardBackward() {
     for (; i_value != a_matrix.end(); i_value++)
         *i_value = 2.33 * (++memberwise_coeficient);
 
-    for (int i = a_matrix.size1() - 1; i >= 0; i--)
-        for (int j = a_matrix.size2() - 1; j >= 0; j--) {
+    for (int i = static_cast<int>(a_matrix.size1() - 1); i >= 0; i--)
+        for (int j = static_cast<int>(a_matrix.size2() - 1); j >= 0; j--) {
             i_value--;
 
             AMATRIX_CHECK_EQUAL(a_matrix(i, j), *i_value);
@@ -37,8 +37,8 @@ int TestMatrixIteratorForwardBackward() {
     for (; i_value != a_matrix.end(); ++i_value)
         *i_value = 1.34 * (++memberwise_coeficient);
 
-    for (int i = a_matrix.size1() - 1; i >= 0; i--)
-        for (int j = a_matrix.size2() - 1; j >= 0; j--) {
+    for (int i = static_cast<int>(a_matrix.size1() - 1); i >= 0; i--)
+        for (int j = static_cast<int>(a_matrix.size2() - 1); j >= 0; j--) {
             AMATRIX_CHECK_EQUAL(a_matrix(i, j), *(--i_value));
         }
 
@@ -61,8 +61,8 @@ int TestMatrixIteratorArithmetic() {
             i_value += 1;
         }
 
-    for (int i = a_matrix.size1() - 1; i >= 0; i--)
-        for (int j = a_matrix.size2() - 1; j >= 0; j--) {
+    for (int i = static_cast<int>(a_matrix.size1() - 1); i >= 0; i--)
+        for (int j = static_cast<int>(a_matrix.size2() - 1); j >= 0; j--) {
             i_value -= 1;
             AMATRIX_CHECK_EQUAL(a_matrix(i, j), *i_value);
         }

--- a/test/test_matrix_lu.cpp
+++ b/test/test_matrix_lu.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 #include <limits>
 
-std::size_t TestMatrixLUDeterminant3() {
+int TestMatrixLUDeterminant3() {
     AMatrix::Matrix<double, 3, 3> a_matrix;
 
     double value = 0.00;
@@ -18,7 +18,7 @@ std::size_t TestMatrixLUDeterminant3() {
     return 0;  // not failed
 }
 
-std::size_t TestMatrixLUInverse3() {
+int TestMatrixLUInverse3() {
     AMatrix::Matrix<double, 3, 3> a_matrix;
     AMatrix::Matrix<double, 3, 3> correct_result{
         -1. / 3., -5. / 3., 1., -1., 4., -2., 1., -2., 1.};
@@ -42,7 +42,7 @@ std::size_t TestMatrixLUInverse3() {
 }
 
 
-std::size_t TestMatrixLUISolve3() {
+int TestMatrixLUISolve3() {
     AMatrix::Matrix<double, 3, 3> a_matrix;
     AMatrix::Matrix<double, 3, 1> b{3., -6., 0.};
     AMatrix::Matrix<double, 3, 1> correct_result{9., -27., 15.};
@@ -65,7 +65,7 @@ std::size_t TestMatrixLUISolve3() {
     return 0;  // not failed
 }
 
-std::size_t TestMatrixLUISolveNoPermutation3() {
+int TestMatrixLUISolveNoPermutation3() {
     AMatrix::Matrix<double, 3, 3> a_matrix{6.,7.,9.
 										  ,0.,1.,2.
 										  ,3.,4.,5.};
@@ -85,7 +85,7 @@ std::size_t TestMatrixLUISolveNoPermutation3() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixLUDeterminant3();
     number_of_failed_tests += TestMatrixLUInverse3();
     number_of_failed_tests += TestMatrixLUISolveNoPermutation3();

--- a/test/test_matrix_minus.cpp
+++ b/test/test_matrix_minus.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixMinus() {
+int TestMatrixMinus() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
     AMatrix::Matrix<double, TSize1, TSize2> c_matrix;
@@ -21,7 +21,7 @@ std::size_t TestMatrixMinus() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixMinusEqual() {
+int TestMatrixMinusEqual() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
@@ -39,7 +39,7 @@ std::size_t TestMatrixMinusEqual() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixMinus<1, 1>();
 
     number_of_failed_tests += TestMatrixMinus<1, 2>();

--- a/test/test_matrix_plus.cpp
+++ b/test/test_matrix_plus.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixPlus() {
+int TestMatrixPlus() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
     AMatrix::Matrix<double, TSize1, TSize2> c_matrix;
@@ -21,7 +21,7 @@ std::size_t TestMatrixPlus() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixPlusEqual() {
+int TestMatrixPlusEqual() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
@@ -39,7 +39,7 @@ std::size_t TestMatrixPlusEqual() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixPlus<1, 1>();
 
     number_of_failed_tests += TestMatrixPlus<1, 2>();

--- a/test/test_matrix_print.cpp
+++ b/test/test_matrix_print.cpp
@@ -3,7 +3,7 @@
 #include "amatrix.h"
 #include "checks.h"
 
-std::size_t TestMatrixPrint() {
+int TestMatrixPrint() {
     AMatrix::Matrix<double, 3, 3> a_matrix;
 
     for (size_t i = 0; i < 9; i++) {
@@ -23,7 +23,7 @@ std::size_t TestMatrixPrint() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixPrint();
 
     std::cout << number_of_failed_tests << "tests failed" << std::endl;

--- a/test/test_matrix_print.cpp
+++ b/test/test_matrix_print.cpp
@@ -7,7 +7,7 @@ int TestMatrixPrint() {
     AMatrix::Matrix<double, 3, 3> a_matrix;
 
     for (size_t i = 0; i < 9; i++) {
-        a_matrix[i] = i * i;
+        a_matrix[i] = static_cast<double>(i * i);
     }
 
     std::stringstream string_stream;

--- a/test/test_matrix_product.cpp
+++ b/test/test_matrix_product.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixScalarProduct() {
+int TestMatrixScalarProduct() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
@@ -21,7 +21,7 @@ std::size_t TestMatrixScalarProduct() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixScalarSelfProduct() {
+int TestMatrixScalarSelfProduct() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
         for (std::size_t j = 0; j < a_matrix.size2(); j++)
@@ -38,7 +38,7 @@ std::size_t TestMatrixScalarSelfProduct() {
 
 template <std::size_t TSize1, std::size_t TSize2,
     std::size_t NumberOfSecondRows>
-std::size_t TestMatrixProduct() {
+int TestMatrixProduct() {
     std::cout << "Testing A(" << TSize1 << "," << TSize2
               << ") X B(" << TSize2 << "," << NumberOfSecondRows
               << ") ";
@@ -69,7 +69,7 @@ std::size_t TestMatrixProduct() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
 
     // scalar product test
     number_of_failed_tests += TestMatrixScalarProduct<1, 1>();

--- a/test/test_matrix_product.cpp
+++ b/test/test_matrix_product.cpp
@@ -54,7 +54,7 @@ int TestMatrixProduct() {
 
     for (std::size_t i = 0; i < b_matrix.size1(); i++)
         for (std::size_t j = 0; j < b_matrix.size2(); j++)
-            b_matrix(i, j) = i + j + 1;
+            b_matrix(i, j) = i + j + 1.00;
 
     c_matrix = a_matrix * b_matrix;
 

--- a/test/test_matrix_row.cpp
+++ b/test/test_matrix_row.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixRowAcess() {
+int TestMatrixRowAcess() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++) {
         for (std::size_t j = 0; j < a_matrix.size2(); j++)
@@ -22,7 +22,7 @@ std::size_t TestMatrixRowAcess() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixRowAssign() {
+int TestMatrixRowAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++) {
         AMatrix::MatrixRow<AMatrix::Matrix<double, TSize1, TSize2>> a_row_i =
@@ -60,7 +60,7 @@ std::size_t TestMatrixRowAssign() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixRowExpressionAssign() {
+int TestMatrixRowExpressionAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++) {
         AMatrix::MatrixRow<AMatrix::Matrix<double, TSize1, TSize2>> a_row_i =
@@ -81,7 +81,7 @@ std::size_t TestMatrixRowExpressionAssign() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
 
     number_of_failed_tests += TestMatrixRowAcess<1, 1>();
     number_of_failed_tests += TestMatrixRowAcess<1, 2>();

--- a/test/test_matrix_scalar_division.cpp
+++ b/test/test_matrix_scalar_division.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixScalarSelfDivision() {
+int TestMatrixScalarSelfDivision() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
         for (std::size_t j = 0; j < a_matrix.size2(); j++)
@@ -18,7 +18,7 @@ std::size_t TestMatrixScalarSelfDivision() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixScalarDivision() {
+int TestMatrixScalarDivision() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
         for (std::size_t j = 0; j < a_matrix.size2(); j++)
@@ -34,7 +34,7 @@ std::size_t TestMatrixScalarDivision() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
 
     // scalar self product test
     number_of_failed_tests += TestMatrixScalarSelfDivision<1, 1>();

--- a/test/test_matrix_scale_and_add.cpp
+++ b/test/test_matrix_scale_and_add.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixScaleAndAdd() {
+int TestMatrixScaleAndAdd() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
     AMatrix::Matrix<double, TSize1, TSize2> c_matrix;
@@ -22,7 +22,7 @@ std::size_t TestMatrixScaleAndAdd() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixScaleAndAddEqual() {
+int TestMatrixScaleAndAddEqual() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     AMatrix::Matrix<double, TSize1, TSize2> b_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
@@ -41,7 +41,7 @@ std::size_t TestMatrixScaleAndAddEqual() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestMatrixScaleAndAdd<1, 1>();
 
     number_of_failed_tests += TestMatrixScaleAndAdd<1, 2>();

--- a/test/test_matrix_sub_matrix.cpp
+++ b/test/test_matrix_sub_matrix.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestSubMatrixAcess() {
+int TestSubMatrixAcess() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
     for (std::size_t i = 0; i < a_matrix.size1(); i++)
         for (std::size_t j = 0; j < a_matrix.size2(); j++)
@@ -31,7 +31,7 @@ std::size_t TestSubMatrixAcess() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestSubMatrixAssign() {
+int TestSubMatrixAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix(
         AMatrix::ZeroMatrix<double>(TSize1, TSize2));
 
@@ -62,7 +62,7 @@ std::size_t TestSubMatrixAssign() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestSubMatrixExpressionAssign() {
+int TestSubMatrixExpressionAssign() {
     AMatrix::Matrix<double, TSize1, TSize2> a_matrix(
         AMatrix::ZeroMatrix<double>(TSize1, TSize2));
 
@@ -97,7 +97,7 @@ std::size_t TestSubMatrixExpressionAssign() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
 
     number_of_failed_tests += TestSubMatrixAcess<1, 1>();
 

--- a/test/test_matrix_transpose.cpp
+++ b/test/test_matrix_transpose.cpp
@@ -37,7 +37,7 @@ int TestMatrixTransposeProduct() {
 
     for (std::size_t i = 0; i < b_matrix.size1(); i++)
         for (std::size_t j = 0; j < b_matrix.size2(); j++)
-            b_matrix(i, j) = i + j + 1;
+            b_matrix(i, j) = i + j + 1.00;
 
     c_matrix = a_matrix * b_matrix.transpose();
 

--- a/test/test_matrix_transpose.cpp
+++ b/test/test_matrix_transpose.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template<std::size_t TSize1, std::size_t TSize2>
-std::size_t TestMatrixTranspose() {
+int TestMatrixTranspose() {
 	AMatrix::Matrix<double, TSize1,TSize2> a_matrix;
 	double b = 0;
 	for (std::size_t i = 0; i < a_matrix.size1(); i++)
@@ -21,7 +21,7 @@ std::size_t TestMatrixTranspose() {
 
 template <std::size_t TSize1, std::size_t TSize2,
     std::size_t NumberOfSecondRows>
-std::size_t TestMatrixTransposeProduct() {
+int TestMatrixTransposeProduct() {
     std::cout << "Testing A(" << TSize1 << "," << TSize2
               << ") X B(" << TSize2 << "," << NumberOfSecondRows
               << ") ";
@@ -53,7 +53,7 @@ std::size_t TestMatrixTransposeProduct() {
 
 int main()
 {
-	std::size_t number_of_failed_tests = 0;
+	int number_of_failed_tests = 0;
 	number_of_failed_tests += TestMatrixTranspose<1,1>();
 
 	number_of_failed_tests += TestMatrixTranspose<1,2>();

--- a/test/test_vector_access.cpp
+++ b/test/test_vector_access.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize>
-std::size_t TestVectorAcess() {
+int TestVectorAcess() {
     AMatrix::Vector<double, TSize> a_vector;
     for (std::size_t i = 0; i < a_vector.size(); i++)
             a_vector[i] = 2.33 * i;
@@ -14,7 +14,7 @@ std::size_t TestVectorAcess() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestVectorAcess<1>();
     number_of_failed_tests += TestVectorAcess<2>();
     number_of_failed_tests += TestVectorAcess<3>();

--- a/test/test_vector_assign.cpp
+++ b/test/test_vector_assign.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template<std::size_t TSize>
-std::size_t TestZeroVectorAssign() {
+int TestZeroVectorAssign() {
 	AMatrix::Vector<double, TSize> a_vector;
 	a_vector = AMatrix::ZeroVector<double>(TSize);
 	
@@ -13,7 +13,7 @@ std::size_t TestZeroVectorAssign() {
 }
 
 template<std::size_t TSize>
-std::size_t TestVectorAssign() {
+int TestVectorAssign() {
 	AMatrix::Vector<double, TSize> a_vector;
 	AMatrix::Vector<double, TSize> b_vector;
 	for (std::size_t i = 0; i < a_vector.size(); i++)
@@ -30,7 +30,7 @@ std::size_t TestVectorAssign() {
 
 int main()
 {
-	std::size_t number_of_failed_tests = 0;
+	int number_of_failed_tests = 0;
 	number_of_failed_tests += TestZeroVectorAssign<1>();
 	number_of_failed_tests += TestZeroVectorAssign<2>();
 	number_of_failed_tests += TestZeroVectorAssign<3>();

--- a/test/test_vector_initialize.cpp
+++ b/test/test_vector_initialize.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize>
-std::size_t TestVectorInitializeToZero() {
+int TestVectorInitializeToZero() {
     const AMatrix::ZeroVector<double> zero_vector(TSize);
     AMatrix::Vector<double, TSize> a_vector(zero_vector);
 
@@ -12,7 +12,7 @@ std::size_t TestVectorInitializeToZero() {
     return 0;  // not failed
 }
 
-std::size_t TestVectorInitialize1() {
+int TestVectorInitialize1() {
     AMatrix::Vector<double, 1> a_vector{1.2};
 
     AMATRIX_CHECK_EQUAL(a_vector[0], 1.2);
@@ -20,7 +20,7 @@ std::size_t TestVectorInitialize1() {
     return 0;  // not failed
 }
 
-std::size_t TestVectorInitialize2() {
+int TestVectorInitialize2() {
     AMatrix::Vector<double, 2> a_vector{1.2, 2.3};
 
     AMATRIX_CHECK_EQUAL(a_vector[0], 1.2);
@@ -29,7 +29,7 @@ std::size_t TestVectorInitialize2() {
     return 0;  // not failed
 }
 
-std::size_t TestVectorInitialize3() {
+int TestVectorInitialize3() {
     AMatrix::Vector<double, 3> a_vector{1.2, 2.3, 3.4};
 
     AMATRIX_CHECK_EQUAL(a_vector[0], 1.2);
@@ -40,7 +40,7 @@ std::size_t TestVectorInitialize3() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestVectorInitializeToZero<1>();
     number_of_failed_tests += TestVectorInitializeToZero<2>();
     number_of_failed_tests += TestVectorInitializeToZero<3>();

--- a/test/test_vector_minus.cpp
+++ b/test/test_vector_minus.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize>
-std::size_t TestVectorMinus() {
+int TestVectorMinus() {
     AMatrix::Vector<double, TSize> a_vector;
     AMatrix::Vector<double, TSize> b_vector;
     AMatrix::Vector<double, TSize> c_vector;
@@ -19,7 +19,7 @@ std::size_t TestVectorMinus() {
 }
 
 template <std::size_t TSize>
-std::size_t TestMatrixMinusEqual() {
+int TestMatrixMinusEqual() {
     AMatrix::Vector<double, TSize> a_vector;
     AMatrix::Vector<double, TSize> b_vector;
     for (std::size_t i = 0; i < a_vector.size(); i++)
@@ -35,7 +35,7 @@ std::size_t TestMatrixMinusEqual() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestVectorMinus<1>();
     number_of_failed_tests += TestVectorMinus<2>();
     number_of_failed_tests += TestVectorMinus<3>();

--- a/test/test_vector_norm.cpp
+++ b/test/test_vector_norm.cpp
@@ -7,7 +7,7 @@ int TestVectorNorm() {
     double results[] = {0, 1, 5, 14, 30, 55, 91, 140, 204, 285};
 
     for (std::size_t i = 0; i < a_vector.size(); i++)
-        a_vector[i] = i + 1;
+        a_vector[i] = i + 1.00;
 
     AMATRIX_CHECK_EQUAL(a_vector.norm(), std::sqrt(results[TSize]));
     AMATRIX_CHECK_EQUAL(a_vector.squared_norm(), results[TSize]);

--- a/test/test_vector_norm.cpp
+++ b/test/test_vector_norm.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize>
-std::size_t TestVectorNorm() {
+int TestVectorNorm() {
     AMatrix::Vector<double, TSize> a_vector;
     double results[] = {0, 1, 5, 14, 30, 55, 91, 140, 204, 285};
 
@@ -17,7 +17,7 @@ std::size_t TestVectorNorm() {
 }
 
 template <std::size_t TSize>
-std::size_t TestVectorNormalize() {
+int TestVectorNormalize() {
     AMatrix::Vector<double, TSize> a_vector;
 
     for (std::size_t i = 0; i < a_vector.size(); i++)
@@ -33,7 +33,7 @@ std::size_t TestVectorNormalize() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
 
     // norm test
     number_of_failed_tests += TestVectorNorm<1>();

--- a/test/test_vector_plus.cpp
+++ b/test/test_vector_plus.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize>
-std::size_t TestVectorPlus() {
+int TestVectorPlus() {
     AMatrix::Vector<double, TSize> a_vector;
     AMatrix::Vector<double, TSize> b_vector;
     AMatrix::Vector<double, TSize> c_vector;
@@ -19,7 +19,7 @@ std::size_t TestVectorPlus() {
 }
 
 template <std::size_t TSize>
-std::size_t TestMatrixPlusEqual() {
+int TestMatrixPlusEqual() {
     AMatrix::Vector<double, TSize> a_vector;
     AMatrix::Vector<double, TSize> b_vector;
     for (std::size_t i = 0; i < a_vector.size(); i++)
@@ -35,7 +35,7 @@ std::size_t TestMatrixPlusEqual() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
     number_of_failed_tests += TestVectorPlus<1>();
     number_of_failed_tests += TestVectorPlus<2>();
     number_of_failed_tests += TestVectorPlus<3>();

--- a/test/test_vector_product.cpp
+++ b/test/test_vector_product.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize>
-std::size_t TestVectorScalarProduct() {
+int TestVectorScalarProduct() {
     AMatrix::Vector<double, TSize> a_vector;
     AMatrix::Vector<double, TSize> b_vector;
     for (std::size_t i = 0; i < a_vector.size(); i++)
@@ -19,7 +19,7 @@ std::size_t TestVectorScalarProduct() {
 }
 
 template <std::size_t TSize>
-std::size_t TestVectorScalarSelfProduct() {
+int TestVectorScalarSelfProduct() {
     AMatrix::Vector<double, TSize> a_vector;
     for (std::size_t i = 0; i < a_vector.size(); i++)
             a_vector[i] = 2.33 * i - 4.52;
@@ -33,7 +33,7 @@ std::size_t TestVectorScalarSelfProduct() {
 }
 
 template <std::size_t TSize>
-std::size_t TestVectorProduct() {
+int TestVectorProduct() {
     AMatrix::Vector<double, TSize> a_vector;
     AMatrix::Vector<double, TSize> b_vector;
 
@@ -54,7 +54,7 @@ std::size_t TestVectorProduct() {
 }
 
 template <std::size_t TSize1, std::size_t TSize2>
-std::size_t TestVectorOuterProduct() {
+int TestVectorOuterProduct() {
     AMatrix::Vector<double, TSize1> a_vector;
     AMatrix::Vector<double, TSize2> b_vector;
 
@@ -81,7 +81,7 @@ std::size_t TestVectorOuterProduct() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
 
     // scalar product test
     number_of_failed_tests += TestVectorScalarProduct<1>();

--- a/test/test_vector_product.cpp
+++ b/test/test_vector_product.cpp
@@ -38,7 +38,7 @@ int TestVectorProduct() {
     AMatrix::Vector<double, TSize> b_vector;
 
     for (std::size_t i = 0; i < a_vector.size(); i++)
-        a_vector[i] = i+1;
+        a_vector[i] = i+1.00;
 
     for (std::size_t i = 0; i < b_vector.size1(); i++)
             b_vector[i] = 5.1;
@@ -59,7 +59,7 @@ int TestVectorOuterProduct() {
     AMatrix::Vector<double, TSize2> b_vector;
 
     for (std::size_t i = 0; i < a_vector.size(); i++)
-        a_vector[i] = i+1;
+        a_vector[i] = i+1.00;
 
     for (std::size_t i = 0; i < b_vector.size(); i++)
             b_vector[i] = 5.1 * i;

--- a/test/test_vector_sub_vector.cpp
+++ b/test/test_vector_sub_vector.cpp
@@ -2,7 +2,7 @@
 #include "checks.h"
 
 template <std::size_t TSize>
-std::size_t TestSubVectorAcess() {
+int TestSubVectorAcess() {
     AMatrix::Vector<double, TSize> a_vector;
     for (std::size_t i = 0; i < a_vector.size(); i++)
         a_vector[i] = 2.33 * i;
@@ -27,7 +27,7 @@ std::size_t TestSubVectorAcess() {
 }
 
 template <std::size_t TSize>
-std::size_t TestSubVectorMemberwiseAssign() {
+int TestSubVectorMemberwiseAssign() {
     AMatrix::Vector<double, TSize> a_vector(
         AMatrix::ZeroMatrix<double>(TSize, 1));
 
@@ -55,7 +55,7 @@ std::size_t TestSubVectorMemberwiseAssign() {
 }
 
 template <std::size_t TSize>
-std::size_t TestSubVectorAssign() {
+int TestSubVectorAssign() {
     AMatrix::Vector<double, TSize> a_vector;
     for (std::size_t i = 0; i < a_vector.size(); i++)
         a_vector[i] = 1.23;
@@ -77,7 +77,7 @@ std::size_t TestSubVectorAssign() {
 }
 
 template <std::size_t TSize>
-std::size_t TestSubVectorPlusEqual() {
+int TestSubVectorPlusEqual() {
     AMatrix::Vector<double, TSize> a_vector;
     for (std::size_t i = 0; i < a_vector.size(); i++)
         a_vector[i] = 1.23;
@@ -103,7 +103,7 @@ std::size_t TestSubVectorPlusEqual() {
 }
 
 template <std::size_t TSize>
-std::size_t TestSubVectorMinusEqual() {
+int TestSubVectorMinusEqual() {
     AMatrix::Vector<double, TSize> a_vector;
     for (std::size_t i = 0; i < a_vector.size(); i++)
         a_vector[i] = 1.23;
@@ -129,7 +129,7 @@ std::size_t TestSubVectorMinusEqual() {
 }
 
 int main() {
-    std::size_t number_of_failed_tests = 0;
+    int number_of_failed_tests = 0;
 
     number_of_failed_tests += TestSubVectorAcess<1>();
     number_of_failed_tests += TestSubVectorAcess<2>();


### PR DESCRIPTION
This PR adds check_aliasing methods to matrix and most of the expressions in order to have the possibility of checking if LHS and RHS have aliasing.

Note that the check itself is not added to AMatrix.