### PR TITLE
Expression iterators

### DIFF
--- a/include/access_category.h
+++ b/include/access_category.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstddef>
+
+namespace AMatrix {
+constexpr std::size_t dynamic = 0;
+constexpr std::size_t row_major_access = 1;
+constexpr std::size_t column_major_access = 2;
+constexpr std::size_t unordered_access = 3;
+
+template <std::size_t TCategory1, std::size_t TCategory2>
+class AccessTrait {
+   public:
+    static constexpr std::size_t category = unordered_access;
+};
+
+template <>
+class AccessTrait<row_major_access, row_major_access> {
+   public:
+    static constexpr std::size_t category = row_major_access;
+};
+
+}

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -113,11 +113,11 @@ class MatrixRow : public MatrixExpression<MatrixRow<TExpressionType>> {
     }
 
     iterator end() {
-        return iterator(_original_expression,_row_index,0,0,1);
+        return iterator(_original_expression,_row_index,_original_expression.size2(),0,1);
     }
 
     const_iterator begin() const {
-        return const_iterator(_original_expression,_row_index,_original_expression.size2(),0,1);
+        return const_iterator(_original_expression,_row_index,0,0,1);
     }
 
     const_iterator end() const {

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -136,6 +136,8 @@ class MatrixColumn : public MatrixExpression<MatrixColumn<TExpressionType>> {
 
    public:
     using data_type = typename TExpressionType::data_type;
+    using iterator = ExpressionRandomAccessIterator<data_type, MatrixColumn<TExpressionType>,TExpressionType::category>;
+    using const_iterator = ExpressionRandomAccessIterator<const data_type, MatrixColumn<TExpressionType>,TExpressionType::category>;
     MatrixColumn() = delete;
 
     MatrixColumn(TExpressionType& Original, std::size_t ColumnIndex)
@@ -178,6 +180,22 @@ class MatrixColumn : public MatrixExpression<MatrixColumn<TExpressionType>> {
     inline std::size_t size() const { return _original_expression.size1(); }
     inline std::size_t size1() const { return _original_expression.size1(); }
     inline std::size_t size2() const { return 1; }
+
+    iterator begin() {
+        return iterator(_original_expression,0,_column_index,1,0);
+    }
+
+    iterator end() {
+        return iterator(_original_expression,_original_expression.size1(),_column_index,1,0);
+    }
+
+    const_iterator begin() const {
+        return const_iterator(_original_expression,0,_column_index,1,0);
+    }
+
+    const_iterator end() const {
+        return const_iterator(_original_expression,_original_expression.size1(),_column_index,1,0);
+    }
 
     bool check_aliasing(const data_type* From, const data_type* To) const {
         return _original_expression.check_aliasing(From, To);

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include "access_category.h"
+#include "matrix_expression_iterator.h"
 
 namespace AMatrix {
 
@@ -62,6 +63,8 @@ class MatrixRow : public MatrixExpression<MatrixRow<TExpressionType>> {
 
    public:
     using data_type = typename TExpressionType::data_type;
+    using iterator = ExpressionRandomAccessIterator<data_type, MatrixRow<TExpressionType>,TExpressionType::category>;
+    using const_iterator = ExpressionRandomAccessIterator<const data_type, MatrixRow<TExpressionType>,TExpressionType::category>;
     MatrixRow() = delete;
 
     MatrixRow(TExpressionType& Original, std::size_t RowIndex)
@@ -104,6 +107,22 @@ class MatrixRow : public MatrixExpression<MatrixRow<TExpressionType>> {
     inline std::size_t size() const { return _original_expression.size2(); }
     inline std::size_t size1() const { return 1; }
     inline std::size_t size2() const { return _original_expression.size2(); }
+
+    iterator begin() {
+        return iterator(_original_expression,_row_index,0,0,1);
+    }
+
+    iterator end() {
+        return iterator(_original_expression,_row_index,0,0,1);
+    }
+
+    const_iterator begin() const {
+        return const_iterator(_original_expression,_row_index,_original_expression.size2(),0,1);
+    }
+
+    const_iterator end() const {
+        return const_iterator(_original_expression,_row_index,_original_expression.size2(),0,1);
+    }
 
     bool check_aliasing(const data_type* From, const data_type* To) const {
         return _original_expression.check_aliasing(From, To);

--- a/include/matrix_expression.h
+++ b/include/matrix_expression.h
@@ -1,24 +1,9 @@
 #pragma once
 
 #include <iostream>
+#include "access_category.h"
 
 namespace AMatrix {
-constexpr std::size_t dynamic = 0;
-constexpr std::size_t row_major_access = 1;
-constexpr std::size_t column_major_access = 2;
-constexpr std::size_t unordered_access = 3;
-
-template <std::size_t TCategory1, std::size_t TCategory2>
-class AccessTrait {
-   public:
-    static constexpr std::size_t category = unordered_access;
-};
-
-template <>
-class AccessTrait<row_major_access, row_major_access> {
-   public:
-    static constexpr std::size_t category = row_major_access;
-};
 
 template <typename TExpressionType, std::size_t TCategory = unordered_access>
 class MatrixExpression {

--- a/include/matrix_expression_iterator.h
+++ b/include/matrix_expression_iterator.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <iterator>
+#include "access_category.h"
+
+namespace AMatrix {
+
+template <typename TDataType, typename TExpressionType, std::size_t TCategory>
+class ExpressionRandomAccessIterator
+    : public std::iterator<std::random_access_iterator_tag, TDataType> {
+
+    TExpressionType& _expression;
+    std::size_t _i;
+    std::size_t _j;
+    const std::size_t _stride_i;
+    const std::size_t _stride_j;
+
+public:
+
+    template <typename TBaseExpression>
+    ExpressionRandomAccessIterator(
+        TBaseExpression& Expression,
+        std::size_t StartI, std::size_t StartJ,
+        std::size_t StrideI, std::size_t StrideJ)
+    : _expression(Expression)
+    , _i(StartI)
+    , _j(StartJ)
+    , _stride_i(StrideI)
+    , _stride_j(StrideJ) {
+    }
+};
+
+template <typename TDataType, typename TExpressionType>
+class ExpressionRandomAccessIterator<TDataType, TExpressionType, row_major_access>
+    : public std::iterator<std::random_access_iterator_tag, TDataType> {
+
+    TDataType* _data;
+    const std::size_t _stride;
+
+public:
+
+    template <typename TBaseExpression>
+    ExpressionRandomAccessIterator(
+        TBaseExpression& Expression,
+        std::size_t StartI, std::size_t StartJ,
+        std::size_t StrideI, std::size_t StrideJ)
+    : _data(&Expression(StartI,StartJ))
+    , _stride(StrideJ + StrideI*Expression.size2()) {
+    }
+
+
+};
+
+}

--- a/include/matrix_expression_iterator.h
+++ b/include/matrix_expression_iterator.h
@@ -34,20 +34,122 @@ template <typename TDataType, typename TExpressionType>
 class ExpressionRandomAccessIterator<TDataType, TExpressionType, row_major_access>
     : public std::iterator<std::random_access_iterator_tag, TDataType> {
 
-    TDataType* _data;
+    TDataType* _p_data;
     const std::size_t _stride;
 
 public:
+    using base_type = std::iterator<std::random_access_iterator_tag, TDataType>;
+    using typename base_type::difference_type;
+    ExpressionRandomAccessIterator() = default;
+    ExpressionRandomAccessIterator(ExpressionRandomAccessIterator const& Other) = default;
+    ExpressionRandomAccessIterator(ExpressionRandomAccessIterator&& Other) = default;
 
     template <typename TBaseExpression>
     ExpressionRandomAccessIterator(
         TBaseExpression& Expression,
         std::size_t StartI, std::size_t StartJ,
         std::size_t StrideI, std::size_t StrideJ)
-    : _data(&Expression(StartI,StartJ))
+    : _p_data(&Expression(StartI,StartJ))
     , _stride(StrideJ + StrideI*Expression.size2()) {
     }
 
+    template <typename TOtherDataType>
+    ExpressionRandomAccessIterator(
+        ExpressionRandomAccessIterator<TOtherDataType, TExpressionType, row_major_access> const& Other)
+    : _p_data(Other.operator->())
+    , _stride(Other._stride) {}
+
+    ExpressionRandomAccessIterator& operator=(
+        ExpressionRandomAccessIterator const& Other) = default;
+
+    bool operator==(const ExpressionRandomAccessIterator& Other) const {
+        return _p_data == Other._p_data;
+    }
+
+    bool operator!=(const ExpressionRandomAccessIterator& Other) const {
+        return _p_data != Other._p_data;
+    }
+
+    TDataType const& operator*() const { return *_p_data; }
+
+    TDataType& operator*() { return *_p_data; }
+
+    TDataType* const operator->() const { return _p_data; }
+
+    TDataType* operator->() { return _p_data; }
+
+    ExpressionRandomAccessIterator& operator++() {
+        _p_data += _stride;
+        return *this;
+    }
+
+    ExpressionRandomAccessIterator operator++(int) {
+        ExpressionRandomAccessIterator temp(*this);
+        _p_data += _stride;
+        return temp;
+    }
+
+    ExpressionRandomAccessIterator& operator--() {
+        _p_data -= _stride;
+        return *this;
+    }
+
+    ExpressionRandomAccessIterator operator--(int) {
+        ExpressionRandomAccessIterator temp(*this);
+        _p_data -= _stride;
+        return temp;
+    }
+
+    ExpressionRandomAccessIterator& operator+=(difference_type Offset) {
+        _p_data += Offset;
+        return *this;
+    }
+
+    ExpressionRandomAccessIterator& operator-=(difference_type Offset) {
+        _p_data -= Offset;
+        return *this;
+    }
+
+    friend ExpressionRandomAccessIterator operator+(
+        ExpressionRandomAccessIterator First, difference_type Second) {
+        First += Second;
+        return First;
+    }
+
+    friend ExpressionRandomAccessIterator operator+(
+        difference_type First, ExpressionRandomAccessIterator Second) {
+        Second += First;
+        return Second;
+    }
+
+    friend ExpressionRandomAccessIterator operator-(
+        ExpressionRandomAccessIterator First, difference_type Second) {
+        First -= Second;
+        return First;
+    }
+
+    friend difference_type operator-(
+        ExpressionRandomAccessIterator const& First, ExpressionRandomAccessIterator const& Second) {
+        return First._p_data - Second._p_data;
+    }
+
+    friend bool operator<(
+        ExpressionRandomAccessIterator const& First, ExpressionRandomAccessIterator const& Second) {
+        return First._p_data < Second._p_data;
+    }
+
+    friend bool operator>(
+        ExpressionRandomAccessIterator const& First, ExpressionRandomAccessIterator const& Second) {
+        return Second < First;
+    }
+    friend bool operator<=(
+        ExpressionRandomAccessIterator const& First, ExpressionRandomAccessIterator const& Second) {
+        return !(First > Second);
+    }
+    friend bool operator>=(
+        ExpressionRandomAccessIterator const& First, ExpressionRandomAccessIterator const& Second) {
+        return !(First < Second);
+    }
 
 };
 

--- a/test/test_matrix_row_col_iterators.cpp
+++ b/test/test_matrix_row_col_iterators.cpp
@@ -9,8 +9,29 @@ int TestMatrixRowExpressionIterator() {
             a_matrix.row(i);
 
         std::size_t j = 0;
-        for ( auto row_iterator = a_row_i.begin(); row_iterator < a_row_i.end(); ++row_iterator)
-            *row_iterator = 2.33 * i - 4.52 * j++;
+        for ( auto row_iterator = a_row_i.begin(); row_iterator < a_row_i.end(); ++row_iterator, j++)
+            *row_iterator = 2.33 * i - 4.52 * j;
+    }
+
+    for (std::size_t i = 0; i < a_matrix.size1(); i++) {
+        for (std::size_t j = 0; j < a_matrix.size2(); j++) {
+            AMATRIX_CHECK_EQUAL(a_matrix(i, j), 2.33 * i - 4.52 * j);
+        }
+    }
+
+    return 0;  // not failed
+}
+
+template <std::size_t TSize1, std::size_t TSize2>
+int TestMatrixColumnExpressionIterator() {
+    AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
+    for (std::size_t j = 0; j < a_matrix.size2(); j++) {
+        AMatrix::MatrixColumn<AMatrix::Matrix<double, TSize1, TSize2>> a_col_j =
+            a_matrix.column(j);
+
+        std::size_t i = 0;
+        for ( auto col_iterator = a_col_j.begin(); col_iterator < a_col_j.end(); ++col_iterator, i++)
+            *col_iterator = 2.33 * i - 4.52 * j;
     }
 
     for (std::size_t i = 0; i < a_matrix.size1(); i++) {
@@ -35,6 +56,17 @@ int main() {
     number_of_failed_tests += TestMatrixRowExpressionIterator<1, 3>();
     number_of_failed_tests += TestMatrixRowExpressionIterator<2, 3>();
     number_of_failed_tests += TestMatrixRowExpressionIterator<3, 3>();
+
+    number_of_failed_tests += TestMatrixColumnExpressionIterator<1, 1>();
+    number_of_failed_tests += TestMatrixColumnExpressionIterator<1, 2>();
+    number_of_failed_tests += TestMatrixColumnExpressionIterator<2, 1>();
+    number_of_failed_tests += TestMatrixColumnExpressionIterator<2, 2>();
+    number_of_failed_tests += TestMatrixColumnExpressionIterator<3, 1>();
+    number_of_failed_tests += TestMatrixColumnExpressionIterator<3, 2>();
+    number_of_failed_tests += TestMatrixColumnExpressionIterator<3, 3>();
+    number_of_failed_tests += TestMatrixColumnExpressionIterator<1, 3>();
+    number_of_failed_tests += TestMatrixColumnExpressionIterator<2, 3>();
+    number_of_failed_tests += TestMatrixColumnExpressionIterator<3, 3>();
 
     return number_of_failed_tests;
 }

--- a/test/test_matrix_row_col_iterators.cpp
+++ b/test/test_matrix_row_col_iterators.cpp
@@ -1,0 +1,40 @@
+#include "amatrix.h"
+#include "checks.h"
+
+template <std::size_t TSize1, std::size_t TSize2>
+int TestMatrixRowExpressionIterator() {
+    AMatrix::Matrix<double, TSize1, TSize2> a_matrix;
+    for (std::size_t i = 0; i < a_matrix.size1(); i++) {
+        AMatrix::MatrixRow<AMatrix::Matrix<double, TSize1, TSize2>> a_row_i =
+            a_matrix.row(i);
+
+        std::size_t j = 0;
+        for ( auto row_iterator = a_row_i.begin(); row_iterator < a_row_i.end(); ++row_iterator)
+            *row_iterator = 2.33 * i - 4.52 * j++;
+    }
+
+    for (std::size_t i = 0; i < a_matrix.size1(); i++) {
+        for (std::size_t j = 0; j < a_matrix.size2(); j++) {
+            AMATRIX_CHECK_EQUAL(a_matrix(i, j), 2.33 * i - 4.52 * j);
+        }
+    }
+
+    return 0;  // not failed
+}
+
+int main() {
+    int number_of_failed_tests = 0;
+
+    number_of_failed_tests += TestMatrixRowExpressionIterator<1, 1>();
+    number_of_failed_tests += TestMatrixRowExpressionIterator<1, 2>();
+    number_of_failed_tests += TestMatrixRowExpressionIterator<2, 1>();
+    number_of_failed_tests += TestMatrixRowExpressionIterator<2, 2>();
+    number_of_failed_tests += TestMatrixRowExpressionIterator<3, 1>();
+    number_of_failed_tests += TestMatrixRowExpressionIterator<3, 2>();
+    number_of_failed_tests += TestMatrixRowExpressionIterator<3, 3>();
+    number_of_failed_tests += TestMatrixRowExpressionIterator<1, 3>();
+    number_of_failed_tests += TestMatrixRowExpressionIterator<2, 3>();
+    number_of_failed_tests += TestMatrixRowExpressionIterator<3, 3>();
+
+    return number_of_failed_tests;
+}


### PR DESCRIPTION
First draft version of iterators for rows and columns, with tests. For now only matrix expressions with category `row_major_access` are supported. I also moved the access category to its own header to solve a cyclic include when defining the new classes.

If we decide to completely drop support for other access categories, I believe that the template structure can be somewhat simplified.